### PR TITLE
Fix various things

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sentry-contrib-native-sys/sentry-native"]
 	path = sentry-contrib-native-sys/sentry-native
-	url = https://github.com/getsentry/sentry-native.git
+	url = https://github.com/EmbarkStudios/sentry-native.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
 nightly = []
 test = []
 custom-transport = ["sys/custom-transport"]
+copy-handler = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
 [features]
 nightly = []
 test = []
+custom-transport = ["sys/custom-transport"]

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,20 @@ fn main() {
         if cfg!(feature = "copy-handler") {
             let out_dir = env::var("OUT_DIR").expect("out dir not set");
 
+            // OUT_DIR will point to a directory unique to each crate, which be something like
+            // target/debug/build/sentry-contrib-native-sys-f734ae671f48a2d5/out, so we go up
+            // 3 parents to get to the root directory (target/debug in this case), which is
+            // where the final binary artifacts will be placed by cargo, so we copy the
+            // crashpad_handler to the same directory to fit with the default expectation the
+            // handler is next to the executable it is monitoring, and so that scripts/programs
+            // that want to package the crashpad_handler along with the executable don't have
+            // to trawl through the target directory looking for it, as, AFAICT, there is no
+            // convenient way to specify the output path of the handler where it is available
+            // to eg other builds scripts, as noted by cargo
+            //
+            // > Note that metadata is only passed to immediate dependents, not transitive dependents.
+            //
+            // And we can't assume that this crate will be a direct dependency of the crate.
             let out_dir = Path::new(&out_dir);
             let bin_dir = out_dir
                 .parent()

--- a/build.rs
+++ b/build.rs
@@ -16,8 +16,34 @@ fn main() {
         println!("{} = {}", k, v);
     }
 
-    if let Ok(p) = env::var("DEP_SENTRY_NATIVE_HANDLER") {
-        println!("cargo:rustc-env=SENTRY_HANDLER={}", p);
-        println!("cargo:SENTRY_HANDLER={}", p);
+    if let Ok(handler) = env::var("DEP_SENTRY_NATIVE_HANDLER") {
+        if cfg!(feature = "copy-handler") {
+            let out_dir = env::var("OUT_DIR").expect("out dir not set");
+
+            let out_dir = Path::new(&out_dir);
+            let bin_dir = out_dir
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap();
+
+            let handler = Path::new(&handler);
+            let bin_path = bin_dir.join(
+                handler
+                    .file_name()
+                    .expect("handler doesn't have a file name"),
+            );
+
+            println!(
+                "cargo:warning=\"Copying {} to {}\"",
+                handler.display(),
+                bin_path.display()
+            );
+            std::fs::copy(&handler, &bin_path).expect("failed to copy sentry crash handler");
+        } else {
+            println!("cargo:rustc-env=SENTRY_HANDLER={}", handler);
+        }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@ fn main() {
     }
 
     if let Ok(p) = env::var("DEP_SENTRY_NATIVE_HANDLER") {
-        println!("cargo:rustc-env=HANDLER={}", Path::new(&p).display(),);
+        println!("cargo:rustc-env=SENTRY_HANDLER={}", p);
+        println!("cargo:SENTRY_HANDLER={}", p);
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -12,10 +12,6 @@
 use std::{env, path::Path};
 
 fn main() {
-    for (k, v) in env::vars() {
-        println!("{} = {}", k, v);
-    }
-
     if let Ok(handler) = env::var("DEP_SENTRY_NATIVE_HANDLER") {
         if cfg!(feature = "copy-handler") {
             let out_dir = env::var("OUT_DIR").expect("out dir not set");
@@ -36,11 +32,6 @@ fn main() {
                     .expect("handler doesn't have a file name"),
             );
 
-            println!(
-                "cargo:warning=\"Copying {} to {}\"",
-                handler.display(),
-                bin_path.display()
-            );
             std::fs::copy(&handler, &bin_path).expect("failed to copy sentry crash handler");
         } else {
             println!("cargo:rustc-env=SENTRY_HANDLER={}", handler);

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,10 @@
 use std::{env, path::Path};
 
 fn main() {
+    for (k, v) in env::vars() {
+        println!("{} = {}", k, v);
+    }
+
     if let Ok(p) = env::var("DEP_SENTRY_NATIVE_HANDLER") {
         println!("cargo:rustc-env=HANDLER={}", Path::new(&p).display(),);
     }

--- a/build.rs
+++ b/build.rs
@@ -47,8 +47,8 @@ fn main() {
             );
 
             std::fs::copy(&handler, &bin_path).expect("failed to copy sentry crash handler");
-        } else {
-            println!("cargo:rustc-env=SENTRY_HANDLER={}", handler);
         }
+
+        println!("cargo:rustc-env=SENTRY_HANDLER={}", handler);
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -12,12 +12,7 @@
 use std::{env, path::Path};
 
 fn main() {
-    let target_os = env::var_os("CARGO_CFG_TARGET_OS").unwrap();
-
-    if target_os == "windows" || target_os == "macos" {
-        println!(
-            "cargo:rustc-env=HANDLER={}",
-            AsRef::<Path>::as_ref(&env::var_os("DEP_SENTRY_NATIVE_HANDLER").unwrap()).display()
-        );
+    if let Ok(p) = env::var("DEP_SENTRY_NATIVE_HANDLER") {
+        println!("cargo:rustc-env=HANDLER={}", Path::new(&p).display(),);
     }
 }

--- a/sentry-contrib-native-sys/Cargo.toml
+++ b/sentry-contrib-native-sys/Cargo.toml
@@ -7,3 +7,6 @@ links = "sentry-native"
 
 [build-dependencies]
 anyhow = "1"
+
+[features]
+custom-transport = []

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -40,21 +40,24 @@ fn main() -> Result<()> {
         );
     }
 
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target os not specified");
+
     if !installed {
         build(&out_dir, &source, &install)?;
     }
 
     println!("cargo:rustc-link-search={}", install.join("lib").display());
     println!("cargo:rustc-link-lib=sentry");
-    println!(
-        "cargo:rustc-link-search={}",
-        install.join("lib64").display()
-    );
 
-    match env::var("CARGO_CFG_TARGET_OS")
-        .expect("target os not specified")
-        .as_str()
-    {
+    let lib_path = if target_os == "windows" {
+        install.join("lib")
+    } else {
+        install.join("lib64")
+    };
+
+    println!("cargo:rustc-link-search={}", lib_path.display());
+
+    match target_os.as_str() {
         crashpad if crashpad == "windows" || crashpad == "macos" => {
             println!("cargo:rustc-link-lib=crashpad_client");
             println!("cargo:rustc-link-lib=crashpad_util");

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -119,6 +119,13 @@ fn build(out_dir: &Path, source: &Path, install: &Path) -> Result<()> {
         "SENTRY_BUILD_EXAMPLES=OFF",
     ]);
 
+    // Apparently cmake defaults to windows 32 bits? wtf
+    if env::var("CARGO_CFG_TARGET_OS").expect("target os not specified") == "windows"
+        && env::var("CARGO_CFG_TARGET_ARCH").expect("target arch not specified") == "x86_64"
+    {
+        cfg_cmd.args(&["-D", "CMAKE_GENERATOR_PLATFORM=x64"]);
+    }
+
     if cfg!(feature = "custom-transport") {
         cfg_cmd.args(&["-D", "SENTRY_TRANSPORT=none"]);
     }

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -46,9 +46,6 @@ fn main() -> Result<()> {
         build(&out_dir, &source, &install)?;
     }
 
-    println!("cargo:rustc-link-search={}", install.join("lib").display());
-    println!("cargo:rustc-link-lib=sentry");
-
     let lib_path = if target_os == "windows" {
         install.join("lib")
     } else {
@@ -56,6 +53,7 @@ fn main() -> Result<()> {
     };
 
     println!("cargo:rustc-link-search={}", lib_path.display());
+    println!("cargo:rustc-link-lib=sentry");
 
     match target_os.as_str() {
         crashpad if crashpad == "windows" || crashpad == "macos" => {
@@ -63,9 +61,7 @@ fn main() -> Result<()> {
             println!("cargo:rustc-link-lib=crashpad_util");
             println!("cargo:rustc-link-lib=mini_chromium");
 
-            let mut handler = String::from("crashpad_handler");
-
-            if crashpad == "windows" {
+            let handler = if crashpad == "windows" {
                 println!("cargo:rustc-link-lib=dbghelp");
                 println!("cargo:rustc-link-lib=shlwapi");
 
@@ -73,8 +69,10 @@ fn main() -> Result<()> {
                     println!("cargo:rustc-link-lib=winhttp");
                 }
 
-                handler.push_str(".exe");
-            }
+                "crashpad_handler.exe"
+            } else {
+                "crashpad_handler"
+            };
 
             println!(
                 "cargo:HANDLER={}",

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -261,6 +261,9 @@ extern "C" {
     #[link_name = "sentry_uuid_nil"]
     pub fn uuid_nil() -> Uuid;
 
+    #[link_name = "sentry_value_add_stacktrace"]
+    pub fn value_add_stacktrace(event: Value, len: usize);
+
     /// Formats the uuid into a string buffer.
     #[link_name = "sentry_uuid_as_string"]
     pub fn uuid_as_string(uuid: *const Uuid, str: *mut c_char);

--- a/src/event.rs
+++ b/src/event.rs
@@ -49,12 +49,11 @@ impl Event {
     /// event.insert("extra", extra);
     /// event.capture();
     /// ```
-    pub fn new_message<L, S>(level: Level, logger: Option<L>, text: S) -> Self
+    pub fn new_message<S>(level: Level, logger: Option<SentryString>, text: S) -> Self
     where
-        L: Into<SentryString>,
         S: Into<SentryString>,
     {
-        let logger = logger.map_or(ptr::null(), |logger| logger.into().as_cstr().as_ptr());
+        let logger = logger.map_or(ptr::null(), |logger| logger.as_cstr().as_ptr());
         let text: CString = text.into().into();
 
         Self(Some(unsafe {

--- a/src/event.rs
+++ b/src/event.rs
@@ -49,12 +49,12 @@ impl Event {
     /// event.insert("extra", extra);
     /// event.capture();
     /// ```
-    pub fn new_message<S: Into<SentryString>>(
-        level: Level,
-        logger: Option<SentryString>,
-        text: S,
-    ) -> Self {
-        let logger = logger.map_or(ptr::null(), |logger| logger.as_cstr().as_ptr());
+    pub fn new_message<L, S>(level: Level, logger: Option<L>, text: S) -> Self
+    where
+        L: Into<SentryString>,
+        S: Into<SentryString>,
+    {
+        let logger = logger.map_or(ptr::null(), |logger| logger.into().as_cstr().as_ptr());
         let text: CString = text.into().into();
 
         Self(Some(unsafe {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -38,11 +38,11 @@ impl CPath for Path {
         let path = self.as_os_str().as_bytes().iter().copied();
         let mut clean_string = Vec::new();
 
-        for char in path {
-            if char == 0 {
-                clean_string.extend(null_string.clone())
+        for ch in path {
+            if ch == 0 {
+                clean_string.extend(null_string)
             } else {
-                clean_string.push(char)
+                clean_string.push(ch)
             }
         }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -40,14 +40,10 @@ impl CPath for Path {
 
         for ch in path {
             if ch == 0 {
-                
-                clean_string.extend(
-                    #[cfg(windows)]
-                    null_string.clone()
-                    #[cfg(not(windows))]
-                    null_string
-                );
-                
+                #[cfg(windows)]
+                clean_string.extend(null_string.clone());
+                #[cfg(not(windows))]
+                clean_string.extend(null_string);
             } else {
                 clean_string.push(ch);
             }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -96,7 +96,15 @@ mod test {
         fn convert(string: &str) -> OsString {
             let path: &Path = OsStr::new(string).as_ref();
             let cpath = path.to_os_vec();
-            OsString::from_wide(&cpath)
+
+            #[cfg(windows)]
+            {
+                OsString::from_wide(&cpath)
+            }
+            #[cfg(not(windows))]
+            {
+                OsString::from_vec(cpath)
+            }
         }
 
         assert_eq!("abcdefgh\0", convert("abcdefgh"));

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -40,9 +40,16 @@ impl CPath for Path {
 
         for ch in path {
             if ch == 0 {
-                clean_string.extend(null_string)
+                
+                clean_string.extend(
+                    #[cfg(windows)]
+                    null_string.clone()
+                    #[cfg(not(windows))]
+                    null_string
+                );
+                
             } else {
-                clean_string.push(ch)
+                clean_string.push(ch);
             }
         }
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -268,7 +268,7 @@ fn list() {
 
     list.push("test1");
     assert_eq!(list.get(4), Some("test1".into()));
-    list.push(&String::from("test2"));
+    list.push(String::from("test2"));
     assert_eq!(list.get(5), Some("test2".into()));
 
     list.push(List::new());

--- a/src/map.rs
+++ b/src/map.rs
@@ -68,8 +68,8 @@ mod test {
         object.insert("test1", ());
         assert_eq!(object.get("test1"), None);
 
-        object.insert(&String::from("test2"), ());
-        assert_eq!(object.get(&String::from("test2")), None);
+        object.insert(String::from("test2").as_ref(), ());
+        assert_eq!(object.get(String::from("test2").as_ref()), None);
 
         object.insert("test3", true);
         assert_eq!(object.get("test3"), Some(true.into()));
@@ -79,21 +79,24 @@ mod test {
         assert_eq!(object.get("test5"), Some(5.5.into()));
         object.insert("test7", "7");
         assert_eq!(object.get("test7"), Some("7".into()));
-        object.insert("test8", &String::from("8"));
-        assert_eq!(object.get("test8"), Some((&String::from("8")).into()));
+        object.insert("test8", String::from("8"));
+        assert_eq!(object.get("test8"), Some((String::from("8")).into()));
 
         object.insert("test9", List::new());
         assert_eq!(object.get("test9"), Some(List::new().into()));
 
         object.insert("test10", Map::new());
-        assert_eq!(object.get(&String::from("test10")), Some(Map::new().into()));
+        assert_eq!(
+            object.get(String::from("test10").as_ref()),
+            Some(Map::new().into())
+        );
 
         object.remove("test3")?;
         assert_eq!(object.get("test3"), None);
         object.remove("test4")?;
         assert_eq!(object.get("test4"), None);
         object.remove("test5")?;
-        assert_eq!(object.get(&String::from("test5")), None);
+        assert_eq!(object.get(String::from("test5").as_ref()), None);
 
         assert_eq!(object.len(), 6);
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -68,8 +68,8 @@ mod test {
         object.insert("test1", ());
         assert_eq!(object.get("test1"), None);
 
-        object.insert(String::from("test2").as_ref(), ());
-        assert_eq!(object.get(String::from("test2").as_ref()), None);
+        object.insert(String::from("test2"), ());
+        assert_eq!(object.get(String::from("test2")), None);
 
         object.insert("test3", true);
         assert_eq!(object.get("test3"), Some(true.into()));
@@ -86,17 +86,14 @@ mod test {
         assert_eq!(object.get("test9"), Some(List::new().into()));
 
         object.insert("test10", Map::new());
-        assert_eq!(
-            object.get(String::from("test10").as_ref()),
-            Some(Map::new().into())
-        );
+        assert_eq!(object.get(String::from("test10")), Some(Map::new().into()));
 
         object.remove("test3")?;
         assert_eq!(object.get("test3"), None);
         object.remove("test4")?;
         assert_eq!(object.get("test4"), None);
         object.remove("test5")?;
-        assert_eq!(object.get(String::from("test5").as_ref()), None);
+        assert_eq!(object.get(String::from("test5")), None);
 
         assert_eq!(object.len(), 6);
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -177,7 +177,7 @@ pub trait Object: Sealed {
 
     /// Workaround for https://github.com/getsentry/sentry-native/issues/235
     fn add_stacktrace(&self, len: usize) {
-        let v = self.unwrap();
+        let v = self.as_raw();
 
         unsafe { sys::value_add_stacktrace(v, len) };
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -174,6 +174,13 @@ pub trait Object: Sealed {
 
         map
     }
+
+    /// Workaround for https://github.com/getsentry/sentry-native/issues/235
+    fn add_stacktrace(&self, len: usize) {
+        let v = self.unwrap();
+
+        unsafe { sys::value_add_stacktrace(v, len) };
+    }
 }
 
 impl<T: Sealed> Object for T {}

--- a/src/options.rs
+++ b/src/options.rs
@@ -510,7 +510,7 @@ impl Options {
         };
         #[cfg(not(windows))]
         unsafe {
-            sys::options_add_attachment(self.as_mut(), name.as_ptr(), path.as_ptr())
+            sys::options_add_attachment(self.as_mut(), name.as_ptr(), path.as_ptr() as *const i8)
         };
     }
 
@@ -547,7 +547,7 @@ impl Options {
         };
         #[cfg(not(windows))]
         unsafe {
-            sys::options_set_handler_path(self.as_mut(), path.as_ptr())
+            sys::options_set_handler_path(self.as_mut(), path.as_ptr() as *const i8)
         };
     }
 
@@ -584,7 +584,7 @@ impl Options {
         };
         #[cfg(not(windows))]
         unsafe {
-            sys::options_set_database_path(self.as_mut(), path.as_ptr())
+            sys::options_set_database_path(self.as_mut(), path.as_ptr() as *const i8)
         };
     }
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -6,8 +6,8 @@ pub fn set_hook() {
     panic::set_hook(Box::new(|panic_info| {
         let mut event = Event::new_message(
             Level::Error,
-            Some("rust panic".into()),
-            &panic_info.to_string(),
+            Some("rust panic"),
+            panic_info.to_string().as_ref(),
         );
 
         if let Some(location) = panic_info.location() {

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -6,8 +6,8 @@ pub fn set_hook() {
     panic::set_hook(Box::new(|panic_info| {
         let mut event = Event::new_message(
             Level::Error,
-            Some("rust panic"),
-            panic_info.to_string().as_ref(),
+            Some("rust panic".into()),
+            panic_info.to_string(),
         );
 
         if let Some(location) = panic_info.location() {

--- a/src/user.rs
+++ b/src/user.rs
@@ -36,12 +36,12 @@ impl User {
     /// # use sentry_contrib_native::{User, Object, Value};
     /// # fn main() -> anyhow::Result<()> {
     /// let mut user = User::new();
-    /// user.set_id(1);
+    /// user.set_id("1");
     /// user.set();
     /// # Ok(()) }
     /// ```
-    pub fn set_id(&mut self, id: i32) {
-        self.insert("id", id)
+    pub fn set_id(&mut self, id: impl Into<SentryString>) {
+        self.insert("id", id.into())
     }
 
     /// Sets the username of the user.
@@ -89,7 +89,7 @@ impl User {
     /// # Ok(()) }
     /// ```
     pub fn set_ip<IP: Into<SocketAddr>>(&mut self, ip: IP) {
-        self.insert("ip", &ip.into().to_string())
+        self.insert("ip", ip.into().to_string())
     }
 
     /// Sets the specified user.

--- a/src/user.rs
+++ b/src/user.rs
@@ -76,7 +76,7 @@ impl User {
         self.insert("email", email.into())
     }
 
-    /// Sets the email of the user.
+    /// Sets the IP address of the user.
     ///
     /// # Examples
     /// ```

--- a/src/value.rs
+++ b/src/value.rs
@@ -183,7 +183,7 @@ impl From<SentryString> for Value {
 
 impl From<String> for Value {
     fn from(value: String) -> Self {
-        SentryString::new(value.as_ref()).into()
+        SentryString::new(value).into()
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -181,9 +181,9 @@ impl From<SentryString> for Value {
     }
 }
 
-impl From<&String> for Value {
-    fn from(value: &String) -> Self {
-        SentryString::new(value).into()
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        SentryString::new(value.as_ref()).into()
     }
 }
 


### PR DESCRIPTION
Sorry this PR is a bit of a mismash of things, these are just the changes I needed to get working in our codebase.

### Build Script Cleanup

It seems the build script wasn't tested when targeting Linux, which doesn't use crashpad for reporting native crashes, so the *sys build script now takes into account all 3 desktop targets.

Added a couple of configuration options to the cmake invocation to turn off tests and examples, as I don't think any Rust crates would need/want those. Also fixed a problem where I guess CMake defaults to 32 bit on windows? so I had linker errors due to no symbols being found because of the arch mismatch.

Also added a cargo feature called `custom-transport` which turns off the compilation/linking of sentry's transport libraries, as eventually we will want to supply our own transport so we don't link against openssl etc, but for now turning on this feature will just get you a broken lib that can't actually report anything as the transport functions aren't exposed to consumers yet.

### Library Cleanup

Made some of the SentryString conversions more ergonomic, too bad specialization still isn't here.

Fixed a few non-Windows errors/lints.

### Stacktrace "Fix"

As noted in https://github.com/getsentry/sentry-native/issues/235#issuecomment-642762932, I changed the native code to add a `sentry_value_add_stacktrace` function that attaches just a "stacktrace" to an object. This is probably the sketchiest change, if you prefer, I could reimplement it on the Rust side, as noted in https://github.com/getsentry/sentry-native/issues/235#issuecomment-637029539