### PR TITLE
Fixup last PR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sentry-contrib-native-sys/sentry-native"]
 	path = sentry-contrib-native-sys/sentry-native
-	url = https://github.com/EmbarkStudios/sentry-native.git
+	url = https://github.com/getsentry/sentry-native.git

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -38,7 +38,19 @@ fn main() -> Result<()> {
         );
     }
 
-    println!("cargo:rustc-link-search={}", install.join("lib").display());
+    // We need to check if there is a `lib64` instead of a `lib` dir, non-Debian
+    // based distros will use that directory instead for 64-bit arches
+    // See: https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html
+    let lib_dir = if install.join("lib64").exists() {
+        "lib64"
+    } else {
+        "lib"
+    };
+
+    println!(
+        "cargo:rustc-link-search={}",
+        install.join(lib_dir).display()
+    );
     println!("cargo:rustc-link-lib=sentry");
 
     match env::var("CARGO_CFG_TARGET_OS")

--- a/src/breadcrumb.rs
+++ b/src/breadcrumb.rs
@@ -28,8 +28,12 @@ impl Breadcrumb {
     /// Creates a new Sentry breadcrumb.
     #[must_use]
     pub fn new(r#type: Option<SentryString>, message: Option<SentryString>) -> Self {
-        let type_ = r#type.map_or(ptr::null(), |type_| CString::from(type_).as_ptr());
-        let message = message.map_or(ptr::null(), |type_| CString::from(type_).as_ptr());
+        let type_ = r#type
+            .as_ref()
+            .map_or(ptr::null(), |ty| ty.as_cstr().as_ptr());
+        let message = message
+            .as_ref()
+            .map_or(ptr::null(), |msg| msg.as_cstr().as_ptr());
 
         Self(Some(unsafe { sys::value_new_breadcrumb(type_, message) }))
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -80,9 +80,9 @@ impl Event {
             sys::event_value_add_stacktrace(event, ptr::null_mut(), len);
 
             let stacktrace_key = b"stacktrace\0".as_ptr() as *const i8;
-
-            let threads = sys::value_get_by_key(event, b"threads\0".as_ptr() as *const i8);
-            let threads_values = sys::value_get_by_key(threads, b"values".as_ptr() as *const i8);
+            let threads_key = b"threads\0".as_ptr() as *const i8;
+            let threads = sys::value_get_by_key(event, threads_key);
+            let threads_values = sys::value_get_by_key(threads, b"values\0".as_ptr() as *const i8);
             let thread = sys::value_get_by_index(threads_values, 0);
             let stacktrace = sys::value_get_by_key(thread, stacktrace_key);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod user;
 mod value;
 
 pub use breadcrumb::Breadcrumb;
-pub use event::{Event, Uuid};
+pub use event::{Event, Exception, Uuid};
 pub use list::List;
 pub use map::Map;
 pub use object::Object;


### PR DESCRIPTION
* You accidentally merged my previous PR's submodule change, this corrects it to use the 0.3.2 branch of the official repo, sorry about that!
* Fixed use after free bug(s) in `Breadcrumb::new()`, it would free the strings pointed at by both type and message, which would result in corrupted strings being sent to sentry, and sentry would apparently just completely swallow the event due the corrupted strings and not even report that there was an issue processing the event, oops!
* Reimplemented the crappy workaround I did for adding stacktraces to the exception object on an event so that the stacktrace would show up nicely in sentry. You can use it like this:

```rust
let mut eve = Event::new();
eve.insert("level", "fatal");
eve.add_exception(sentry_native::Exception::new("panic", msg), 0);
eve.capture();
```

Let me know if you like that change and I can document the Exception object (right now it complains about missing docs).