### PR TITLE
Add custom transports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             }
           - { name: "", transport: default_transport, custom-transport: false }
           - {
-              name: "--features test, custom-transport",
+              name: "--features test,custom-transport",
               custom-transport: true,
               transport: default_transport,
             }
@@ -248,7 +248,7 @@ jobs:
             }
           - { name: "", transport: default_transport, custom-transport: false }
           - {
-              name: "--features test, custom-transport",
+              name: "--features test,custom-transport",
               custom-transport: true,
               transport: default_transport,
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Audit
+        # Ignore net2 deprecation, only used by examples
+        # Ignore spin deprecation, only used by examples
         run: |
           cargo audit -D \
-          --ignore RUSTSEC-2020-0016 \ # Ignore net2 deprecation, only used by examples
-          --ignore RUSTSEC-2019-0031 # Ignore spin deprecation, only used by examples
+          --ignore RUSTSEC-2020-0016 \
+          --ignore RUSTSEC-2019-0031
 
   prettier:
     if: github.event_name != 'schedule'
@@ -111,8 +113,7 @@ jobs:
         run: echo "::set-env name=SENTRY_NATIVE_INSTALL::$HOME/sentry-native"
       - name: Build
         id: build
-        run:
-          cargo -v build ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
+        run: cargo -v build ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
       - name: Clippy
         if: always() && steps.build.outcome == 'success'
         run:
@@ -129,8 +130,7 @@ jobs:
         if: always() && steps.build.outcome == 'success'
         env:
           RUSTDOCFLAGS: -F warnings
-        run:
-          cargo -v doc --no-deps --document-private-items --workspace ${{
+        run: cargo -v doc --no-deps --document-private-items --workspace ${{
           matrix.feature.name }} ${{ matrix.rust.feature }}
       - name: Rust Formatting
         if: always() && steps.checkout.outcome == 'success'
@@ -261,8 +261,7 @@ jobs:
         run: echo "::set-env name=SENTRY_NATIVE_INSTALL::$HOME/sentry-native"
       - name: Build
         id: build
-        run:
-          cargo -v build ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
+        run: cargo -v build ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
       - name: Clippy
         if: always() && steps.build.outcome == 'success'
         run:
@@ -279,8 +278,7 @@ jobs:
         if: always() && steps.build.outcome == 'success'
         env:
           RUSTDOCFLAGS: -F warnings
-        run:
-          cargo -v doc --no-deps --document-private-items --workspace ${{
+        run: cargo -v doc --no-deps --document-private-items --workspace ${{
           matrix.feature.name }} ${{ matrix.rust.feature }}
       - name: Rust Formatting
         if: always() && steps.checkout.outcome == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Audit
-        run: cargo audit -D
+        run: |
+          cargo audit -D \
+          --ignore RUSTSEC-2020-0016 \ # Ignore net2 deprecation, only used by examples
+          --ignore RUSTSEC-2019-0031 # Ignore spin deprecation, only used by examples
 
   prettier:
     if: github.event_name != 'schedule'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,8 @@ jobs:
         run: echo "::set-env name=SENTRY_NATIVE_INSTALL::$HOME/sentry-native"
       - name: Build
         id: build
-        run: cargo -v build ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
+        run:
+          cargo -v build ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
       - name: Clippy
         if: always() && steps.build.outcome == 'success'
         run:
@@ -130,7 +131,8 @@ jobs:
         if: always() && steps.build.outcome == 'success'
         env:
           RUSTDOCFLAGS: -F warnings
-        run: cargo -v doc --no-deps --document-private-items --workspace ${{
+        run:
+          cargo -v doc --no-deps --document-private-items --workspace ${{
           matrix.feature.name }} ${{ matrix.rust.feature }}
       - name: Rust Formatting
         if: always() && steps.checkout.outcome == 'success'
@@ -261,7 +263,8 @@ jobs:
         run: echo "::set-env name=SENTRY_NATIVE_INSTALL::$HOME/sentry-native"
       - name: Build
         id: build
-        run: cargo -v build ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
+        run:
+          cargo -v build ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
       - name: Clippy
         if: always() && steps.build.outcome == 'success'
         run:
@@ -278,7 +281,8 @@ jobs:
         if: always() && steps.build.outcome == 'success'
         env:
           RUSTDOCFLAGS: -F warnings
-        run: cargo -v doc --no-deps --document-private-items --workspace ${{
+        run:
+          cargo -v doc --no-deps --document-private-items --workspace ${{
           matrix.feature.name }} ${{ matrix.rust.feature }}
       - name: Rust Formatting
         if: always() && steps.checkout.outcome == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,17 @@ jobs:
               feature: --features nightly,
             }
         feature:
-          - { name: --no-default-features, transport: no_transport }
-          - { name: "", transport: default_transport }
-          - { name: --features test, transport: default_transport }
+          - {
+              name: --no-default-features --features custom-transport,
+              transport: no_transport,
+              custom-transport: true,
+            }
+          - { name: "", transport: default_transport, custom-transport: false }
+          - {
+              name: "--features test, custom-transport",
+              custom-transport: true,
+              transport: default_transport,
+            }
         os:
           - ubuntu-latest
           - macos-latest
@@ -127,6 +135,24 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: cargo -v test ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
+      - name: Example
+        if:
+          always() && steps.build.outcome == 'success' && matrix.feature.name ==
+          '--features test'
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run:
+          cargo -v run --example example ${{ matrix.feature.name }} ${{
+          matrix.rust.feature }}
+      - name: Custom transport example
+        if:
+          always() && steps.build.outcome == 'success' && matrix.feature.name ==
+          '--features test' && matrix.feature.custom-transport
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run:
+          cargo -v run --example custom-transport ${{ matrix.feature.name }} ${{
+          matrix.rust.feature }}
       - name: Documentation
         if: always() && steps.build.outcome == 'success'
         env:
@@ -215,9 +241,17 @@ jobs:
               feature: --features nightly,
             }
         feature:
-          - { name: --no-default-features, transport: no_transport }
-          - { name: "", transport: default_transport }
-          - { name: --features test, transport: default_transport }
+          - {
+              name: --no-default-features --features custom-transport,
+              transport: no_transport,
+              custom-transport: true,
+            }
+          - { name: "", transport: default_transport, custom-transport: false }
+          - {
+              name: "--features test, custom-transport",
+              custom-transport: true,
+              transport: default_transport,
+            }
         os:
           - ubuntu-latest
           - macos-latest
@@ -277,6 +311,24 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: cargo -v test ${{ matrix.feature.name }} ${{ matrix.rust.feature }}
+      - name: Example
+        if:
+          always() && steps.build.outcome == 'success' && matrix.feature.name ==
+          '--features test'
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run:
+          cargo -v run --example example ${{ matrix.feature.name }} ${{
+          matrix.rust.feature }}
+      - name: Custom transport example
+        if:
+          always() && steps.build.outcome == 'success' && matrix.feature.name ==
+          '--features test' && matrix.feature.custom-transport
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run:
+          cargo -v run --example custom-transport ${{ matrix.feature.name }} ${{
+          matrix.rust.feature }}
       - name: Documentation
         if: always() && steps.build.outcome == 'success'
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,8 +43,8 @@ jobs:
         env:
           RUSTDOCFLAGS: -Z unstable-options --enable-index-page
         run:
-          cargo -v doc --features nightly --no-deps --document-private-items
-          --workspace
+          cargo -v doc --features custom-transport,nightly --no-deps
+          --document-private-items --workspace
       - name: Deploy
         if: success()
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
 # Used by the custom-transport example
 parking_lot = "0.10"
 reqwest = { version = "0.10", default-features = false, features = ["rustls-tls"] }
-tokio = { verion = "0.2", features = ["rt-threaded"] }
+tokio = { version = "0.2", features = ["rt-threaded"] }
 
 [features]
 default = ["default-transport"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ edition = "2018"
 members = ["sentry-contrib-native-sys"]
 
 [dependencies]
+http = { version = "0.2", optional = true }
 once_cell = "1"
 rmpv = "0.4"
 sys = { package = "sentry-contrib-native-sys", path = "sentry-contrib-native-sys", default-features = false }
 thiserror = "1"
+url = { version = "2.1", optional = true }
 vsprintf = { git = "https://github.com/daxpedda/vsprintf", branch = "fix-windows" }
 
 [dev-dependencies]
@@ -23,5 +25,6 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
 [features]
 default = ["default-transport"]
 default-transport = ["sys/default-transport"]
+custom-transport = ["http", "url"]
 nightly = []
 test = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
   "macro"
 ] }
 
-# Used by the custom-transport example
-parking_lot = "0.10"
-reqwest = { version = "0.10", default-features = false, features = ["rustls-tls"] }
+# Used by the custom-transport example.
+parking_lot = "0.11"
+reqwest = { version = "0.10", default-features = false, features = [
+  "rustls-tls"
+] }
 tokio = { version = "0.2", features = ["rt-threaded"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,18 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
   "macro"
 ] }
 
+# Used by the custom-transport example
+parking_lot = "0.10"
+reqwest = { version = "0.10", default-features = false, features = ["rustls-tls"] }
+tokio = { verion = "0.2", features = ["rt-threaded"] }
+
 [features]
 default = ["default-transport"]
 default-transport = ["sys/default-transport"]
 custom-transport = ["http", "url"]
 nightly = []
 test = []
+
+[[example]]
+name = "custom-transport"
+required-features = ["custom-transport"]

--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ for more details.
 
 - **default-transport** - **Enabled by default**, will use `winhttp` on Windows
   and `curl` everywhere else as the default transport.
-- **custom-transport** - Allows you to register your own transport with the SDK
-  to use instead of the default transports.
+- **custom-transport** - Adds helper types and methods to custom transport.
 - **test** - Corrects testing for documentation tests and examples.
   - Automatically sets the DSN to the `SENTRY_DSN` environment variable, no
     matter what is set through `Options::set_dsn`.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ for more details.
 
 - **default-transport** - **Enabled by default**, will use `winhttp` on Windows
   and `curl` everywhere else as the default transport.
+- **custom-transport** - Allows you to register your own transport with the SDK
+to use instead of the default transports.
 - **test** - Corrects testing for documentation tests and examples.
   - Automatically sets the DSN to the `SENTRY_DSN` environment variable, no
     matter what is set through `Options::set_dsn`.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ for more details.
 - **default-transport** - **Enabled by default**, will use `winhttp` on Windows
   and `curl` everywhere else as the default transport.
 - **custom-transport** - Allows you to register your own transport with the SDK
-to use instead of the default transports.
+  to use instead of the default transports.
 - **test** - Corrects testing for documentation tests and examples.
   - Automatically sets the DSN to the `SENTRY_DSN` environment variable, no
     matter what is set through `Options::set_dsn`.

--- a/examples/custom-transport.rs
+++ b/examples/custom-transport.rs
@@ -1,0 +1,191 @@
+use sentry_contrib_native as sentry;
+use sentry::PostedEnvelope;
+use parking_lot::{Mutex, Condvar};
+use tokio::sync::mpsc;
+use std::sync::Arc;
+
+struct TransportState {
+    tx: mpsc::Sender<PostedEnvelope>,
+    shutdown: Arc<(Mutex<()>, Condvar)>,
+}
+
+async fn send_sentry_request(
+    client: &reqwest::Client,
+    req: sentry::SentryRequest,
+) -> Result<(), String> {
+    let (parts, body) = req.into_parts();
+    let uri = parts.uri.to_string();
+
+    // Sentry should only give us POST requests to send
+    if parts.method != http::Method::POST {
+        return Err(format!("Sentry SDK is trying to send an unexpected request of '{}'", parts.method));
+    }
+    
+    let rb = client.post(&parts.uri.to_string());
+
+    // We cheat so that we don't have to copy all of the bytes of the body
+    // into a new buffer, but we have to fake that the slice is static, which
+    // should be ok since we only need that buffer until the request is finished
+    #[allow(unsafe_code)]
+    let buffer = unsafe {
+        let buf = body.as_ref();
+        std::slice::from_raw_parts::<'static, u8>(buf.as_ptr(), buf.len())
+    };
+
+    let res = rb
+        .headers(parts.headers)
+        .body(reqwest::Body::from(buffer))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to send Sentry request: {}", e))?;
+
+    res.error_for_status()
+        .map_err(|e| format!("Received error response from Sentry: {}", e))?;
+    Ok(())
+}
+
+// We can implement our own transport for Sentry data so that we don't pull in
+// C dependencies (COUGH OPENSSL COUGH) that we don't want
+struct ReqwestTransport {
+    /// We don't currently use custom certs or proxies, so we can just use the
+    /// same client that the rest of ark uses, if we do start doing that, we
+    /// would need to build the client based on the options during startup()
+    client: reqwest::Client,
+    inner: Mutex<Option<TransportState>>,
+    rt: tokio::runtime::Handle,
+}
+
+impl ReqwestTransport {
+    fn new(client: reqwest::Client, rt: tokio::runtime::Handle) -> Self {
+        Self {
+            client,
+            inner: Mutex::new(None),
+            rt,
+        }
+    }
+}
+
+impl sentry::TransportWorker for ReqwestTransport {
+    fn startup(&self, dsn: sentry::Dsn, _debug: bool) {
+        let mut inner = self.inner.lock();
+        match *inner {
+            Some(_) => {
+                eprintln!("sentry transport has already been started!");
+            }
+            None => {
+                let (tx, mut rx) = mpsc::channel(1024);
+                let shutdown = Arc::new((Mutex::new(()), Condvar::new()));
+                let tshutdown = shutdown.clone();
+                let client = self.client.clone();
+
+                self.rt.enter(|| {
+                    tokio::spawn(async move {
+                        // Dequeue and send events until we are asked to shut down
+                        while let Some(envelope) = rx.recv().await {
+                            // Convert the envelope into an HTTP request
+                            match Self::convert_to_request(&dsn, envelope) {
+                                Ok(req) => match send_sentry_request(&client, req).await {
+                                    Ok(_) => eprintln!("successfully sent sentry envelope"),
+                                    Err(err) => {
+                                        eprintln!("failed to send sentry envelope: {}", err)
+                                    }
+                                },
+                                Err(err) => {
+                                    eprintln!("failed to convert Sentry request: {}", err);
+                                }
+                            }
+                        }
+
+                        // Shutting down, signal the condition variable that we've
+                        // finished sending everything, so that we can tell the
+                        // SDK about whether we've sent it all before their timeout
+                        let (lock, cvar) = &*tshutdown;
+                        let _shutdown = lock.lock();
+                        cvar.notify_one();
+                    });
+                });
+
+                *inner = Some(TransportState { tx, shutdown });
+            }
+        }
+    }
+
+    fn send(&self, envelope: PostedEnvelope) {
+        let inner = self.inner.lock();
+        if let Some(inner) = &*inner {
+            let mut tx = inner.tx.clone();
+            self.rt.enter(|| {
+                tokio::task::spawn(async move {
+                    if let Err(err) = tx.send(envelope).await {
+                        eprintln!("failed to send envelope to send queue: {}", err);
+                    }
+                });
+            });
+        }
+    }
+
+    fn shutdown(&self, timeout: std::time::Duration) -> sentry::TransportShutdown {
+        // Drop the sender so that the background thread will exit once
+        // it has dequeued and processed all the envelopes we have enqueued
+        let inner = self.inner.lock().take();
+
+        match inner {
+            Some(inner) => {
+                drop(inner.tx);
+
+                // Wait for the condition variable to notify that the thread has shutdown
+                let (lock, cvar) = &*inner.shutdown;
+                let mut shutdown = lock.lock();
+                let result = cvar.wait_for(&mut shutdown, timeout);
+
+                if result.timed_out() {
+                    sentry::TransportShutdown::TimedOut
+                } else {
+                    sentry::TransportShutdown::Success
+                }
+            }
+            None => sentry::TransportShutdown::Success,
+        }
+    }
+}
+
+fn main() -> Result<(), String> {
+    let mut options = sentry::Options::new();
+
+    // Setting a DSN is absolutely required to use custom transports
+    options.set_dsn("https://1234abcd@your.sentry.service.com/1234");
+
+    // This debug flag is supplied to our custom transport if we want to eg
+    // print debug information etc just as the underlying SDK does
+    options.set_debug(true);
+
+    // Setup a runtime, if you're using tokio or some other async runtime to
+    // send requests, you'll need to pass the handle to your transport so that
+    // you can actually spawn tasks correctly, since the calls are going to
+    // come on threads created by the C lib itself and won't have a runtime
+    // installed
+    let runtime = tokio::runtime::Builder::new()
+        .threaded_scheduler()
+        .enable_all()
+        .thread_name("sentry-tokio")
+        .build()
+        .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
+
+    // In this case we are creating a client just for the transport, but in
+    // a real app it is likely you would have this configured for other things
+    // and just reuse it for Sentry. If you are using proxies are custom certs
+    // with Sentry, you could also configure it here, or during startup, using
+    // the options you set
+    let client = reqwest::Client::new();
+
+    // Actually registers our custom transport so that the SDK will use that to
+    // send requests to your Sentry service, rather than the built in transports
+    // that come with the SDK
+    options.set_transport(sentry::Transport::new(Box::new(
+        ReqwestTransport::new(client, runtime.handle().clone()),
+    )));
+
+    let _shutdown = options.init().map_err(|e| format!("Failed to initialize Sentry: {}", e))?;
+
+    Ok(())
+}

--- a/examples/custom-transport.rs
+++ b/examples/custom-transport.rs
@@ -14,7 +14,7 @@ async fn send_sentry_request(
     req: sentry::SentryRequest,
 ) -> Result<(), String> {
     let (parts, body) = req.into_parts();
-    let uri = parts.uri.to_string();
+    //let uri = parts.uri.to_string();
 
     // Sentry should only give us POST requests to send
     if parts.method != http::Method::POST {
@@ -86,16 +86,11 @@ impl sentry::TransportWorker for ReqwestTransport {
                         // Dequeue and send events until we are asked to shut down
                         while let Some(envelope) = rx.recv().await {
                             // Convert the envelope into an HTTP request
-                            match Self::convert_to_request(&dsn, envelope) {
-                                Ok(req) => match send_sentry_request(&client, req).await {
-                                    Ok(_) => eprintln!("successfully sent sentry envelope"),
-                                    Err(err) => {
-                                        eprintln!("failed to send sentry envelope: {}", err)
-                                    }
-                                },
-                                Err(err) => {
-                                    eprintln!("failed to convert Sentry request: {}", err);
-                                }
+                            let req = Self::convert_to_request(&dsn, envelope);
+
+                            match send_sentry_request(&client, req).await {
+                                Ok(_) => eprintln!("successfully sent sentry envelope"),
+                                Err(err) => eprintln!("failed to send sentry envelope: {}", err),
                             }
                         }
 

--- a/examples/custom-transport.rs
+++ b/examples/custom-transport.rs
@@ -5,6 +5,8 @@
     clippy::pedantic,
     missing_docs
 )]
+// stable clippy seems to have an issue with await
+#![allow(clippy::used_underscore_binding)]
 
 //!
 

--- a/examples/custom-transport.rs
+++ b/examples/custom-transport.rs
@@ -1,5 +1,5 @@
-use parking_lot::{Condvar, Mutex};
-use sentry::PostedEnvelope;
+/*use parking_lot::{Condvar, Mutex};
+use sentry::{Event, PostedEnvelope};
 use sentry_contrib_native as sentry;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -188,5 +188,10 @@ fn main() -> Result<(), String> {
         .init()
         .map_err(|e| format!("Failed to initialize Sentry: {}", e))?;
 
+    Event::new().capture();
+
     Ok(())
 }
+*/
+
+fn main() {}

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,3 +1,13 @@
+#![warn(
+    clippy::all,
+    clippy::missing_docs_in_private_items,
+    clippy::nursery,
+    clippy::pedantic,
+    missing_docs
+)]
+
+//!
+
 use anyhow::Result;
 use sentry::Options;
 use sentry_contrib_native as sentry;

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -74,18 +74,13 @@ fn main() -> Result<()> {
             let handler = if crashpad == "windows" {
                 println!("cargo:rustc-link-lib=dbghelp");
                 println!("cargo:rustc-link-lib=shlwapi");
-
-                if cfg!(feature = "default-transport") {
-                    println!("cargo:rustc-link-lib=winhttp");
-                }
+                println!("cargo:rustc-link-lib=winhttp");
 
                 "crashpad_handler.exe"
             } else {
                 println!("cargo:rustc-link-lib=framework=Foundation");
 
-                if cfg!(feature = "default-transport") {
-                    println!("cargo:rustc-link-lib=curl");
-                }
+                println!("cargo:rustc-link-lib=curl");
 
                 println!("cargo:rustc-link-lib=dylib=c++");
 

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -96,12 +96,33 @@ pub enum UserConsent {
     Revoked = 0,
 }
 
+/// This represents an interface for user-defined transports.
+#[repr(C)]
+pub struct Transport([u8; 0]);
+
+/// A Sentry Envelope.
+///
+/// The Envelope is an abstract type which represents a payload being sent to
+/// sentry. It can contain one or more items, typically an Event.
+/// See <https://develop.sentry.dev/sdk/envelopes/>
+#[repr(C)]
+pub struct Envelope([u8; 0]);
+
 /// Type of the callback for modifying events.
 pub type EventFunction =
     extern "C" fn(event: Value, hint: *mut c_void, closure: *mut c_void) -> Value;
 
 /// Type of the callback for logging debug events.
 pub type LoggerFunction = extern "C" fn(level: i32, message: *const c_char, args: *mut c_void);
+
+/// Type of callback for sending envelopes to a Sentry service
+pub type SendEnvelopeFunction = extern "C" fn(envelope: *mut Envelope, state: *mut c_void);
+
+/// Type of the callback for starting up a custom transport
+pub type StartupFunction = extern "C" fn(options: *const Options, state: *mut c_void);
+
+/// Type of the callback for shutting down a custom transport
+pub type ShutdownFunction = extern "C" fn(timeout: u64, state: *mut c_void) -> bool;
 
 extern "C" {
     /// Releases memory allocated from the underlying allocator.
@@ -268,6 +289,50 @@ extern "C" {
     #[link_name = "sentry_uuid_as_string"]
     pub fn uuid_as_string(uuid: *const Uuid, str: *mut c_char);
 
+    /// Frees an envelope.
+    #[link_name = "sentry_envelope_free"]
+    pub fn envelope_free(envelope: *mut Envelope);
+
+    /// Serializes the envelope.
+    ///
+    /// The return value needs to be freed with `sentry_string_free()`.
+    #[link_name = "sentry_envelope_serialize"]
+    pub fn envelope_serialize(envelope: *const Envelope, size: &mut usize) -> *const c_char;
+
+    /// Creates a new transport with an initial `send_func`.
+    #[link_name = "sentry_transport_new"]
+    pub fn transport_new(send_fn: SendEnvelopeFunction) -> *mut Transport;
+
+    /// Sets the transport `state`.
+    ///
+    /// If the state is owned by the transport and needs to be freed, use
+    /// `transport_set_free_func` to set an appropriate hook.
+    #[link_name = "sentry_transport_set_state"]
+    pub fn transport_set_state(transport: *mut Transport, state: *mut c_void);
+
+    /// Sets the transport hook to free the transport `state`.
+    #[link_name = "sentry_transport_set_free_func"]
+    pub fn transport_set_free_func(
+        transport: *mut Transport,
+        free_fn: extern "C" fn(state: *mut c_void),
+    );
+
+    /// Sets the transport startup hook.
+    #[link_name = "sentry_transport_set_startup_func"]
+    pub fn transport_set_startup_hook(transport: *mut Transport, startup_fn: StartupFunction);
+
+    /// Sets the transport shutdown hook.
+    ///
+    /// This hook will receive a millisecond-resolution timeout; it should return
+    /// `true` in case all the pending envelopes have been sent within the timeout,
+    /// or `false` if the timeout was hit.
+    #[link_name = "sentry_transport_set_shutdown_func"]
+    pub fn transport_set_shutdown_func(transport: *mut Transport, shutdown_fn: ShutdownFunction);
+
+    /// Generic way to free a transport.
+    #[link_name = "sentry_transport_free"]
+    pub fn transport_free(transport: *mut Transport);
+
     /// Creates a new options struct.
     /// Can be freed with `sentry_options_free`.
     #[link_name = "sentry_options_new"]
@@ -276,6 +341,10 @@ extern "C" {
     /// Deallocates previously allocated Sentry options.
     #[link_name = "sentry_options_free"]
     pub fn options_free(opts: *mut Options);
+
+    /// Sets a transport.
+    #[link_name = "sentry_options_set_transport"]
+    pub fn options_set_transport(opts: *mut Options, transport: *mut Transport);
 
     /// Sets the before send callback.
     #[link_name = "sentry_options_set_before_send"]

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -338,7 +338,7 @@ extern "C" {
     #[link_name = "sentry_transport_set_free_func"]
     pub fn transport_set_free_func(
         transport: *mut Transport,
-        free_fn: extern "C" fn(state: *mut c_void),
+        free_func: Option<extern "C" fn(state: *mut c_void)>,
     );
 
     /// Sets the transport startup hook.

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -321,7 +321,7 @@ extern "C" {
     ///
     /// The return value needs to be freed with `sentry_string_free()`.
     #[link_name = "sentry_envelope_serialize"]
-    pub fn envelope_serialize(envelope: *const Envelope, size: &mut usize) -> *const c_char;
+    pub fn envelope_serialize(envelope: *const Envelope, size: *mut usize) -> *const c_char;
 
     /// Creates a new transport with an initial `send_func`.
     #[link_name = "sentry_transport_new"]

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -343,7 +343,10 @@ extern "C" {
 
     /// Sets the transport startup hook.
     #[link_name = "sentry_transport_set_startup_func"]
-    pub fn transport_set_startup_func(transport: *mut Transport, startup_func: Option<StartupFunction>);
+    pub fn transport_set_startup_func(
+        transport: *mut Transport,
+        startup_func: Option<StartupFunction>,
+    );
 
     /// Sets the transport shutdown hook.
     ///
@@ -351,7 +354,10 @@ extern "C" {
     /// `true` in case all the pending envelopes have been sent within the timeout,
     /// or `false` if the timeout was hit.
     #[link_name = "sentry_transport_set_shutdown_func"]
-    pub fn transport_set_shutdown_func(transport: *mut Transport, shutdown_func: Option<ShutdownFunction>);
+    pub fn transport_set_shutdown_func(
+        transport: *mut Transport,
+        shutdown_func: Option<ShutdownFunction>,
+    );
 
     /// Generic way to free a transport.
     #[link_name = "sentry_transport_free"]

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -325,7 +325,7 @@ extern "C" {
 
     /// Creates a new transport with an initial `send_func`.
     #[link_name = "sentry_transport_new"]
-    pub fn transport_new(send_fn: SendEnvelopeFunction) -> *mut Transport;
+    pub fn transport_new(send_func: Option<SendEnvelopeFunction>) -> *mut Transport;
 
     /// Sets the transport `state`.
     ///

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -343,7 +343,7 @@ extern "C" {
 
     /// Sets the transport startup hook.
     #[link_name = "sentry_transport_set_startup_func"]
-    pub fn transport_set_startup_hook(transport: *mut Transport, startup_fn: StartupFunction);
+    pub fn transport_set_startup_func(transport: *mut Transport, startup_func: Option<StartupFunction>);
 
     /// Sets the transport shutdown hook.
     ///

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -128,6 +128,7 @@ pub struct Transport([u8; 0]);
 /// sentry. It can contain one or more items, typically an Event.
 /// See <https://develop.sentry.dev/sdk/envelopes/>
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Envelope([u8; 0]);
 
 /// Type of the callback for modifying events.

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -97,6 +97,28 @@ pub enum UserConsent {
 }
 
 /// This represents an interface for user-defined transports.
+///
+/// Transports are responsible for sending envelopes to sentry and are the last
+/// step in the event pipeline. A transport has the following hooks, all of which
+/// take the user provided `state` as last parameter. The transport state needs
+/// to be set with `sentry_transport_set_state` and typically holds handles and
+/// other information that can be reused across requests.
+///
+/// * `send_func`: This function will take ownership of an envelope, and is
+///   responsible for freeing it via `sentry_envelope_free`.
+/// * `startup_func`: This hook will be called by sentry and instructs the
+///   transport to initialize itself.
+/// * `shutdown_func`: Instructs the transport to flush its queue and shut down.
+///   This hook receives a millisecond-resolution `timeout` parameter and should
+///   return `true` when the transport was flushed and shut down successfully.
+///   In case of `false`, sentry will log an error, but continue with freeing the
+///   transport.
+/// * `free_func`: Frees the transports `state`. This hook might be called even
+///   though `shudown_func` returned `false` previously.
+///
+/// The transport interface might be extended in the future with hooks to flush
+/// its internal queue without shutting down, and to dump its internal queue to
+/// disk in case of a hard crash.
 #[repr(C)]
 pub struct Transport([u8; 0]);
 

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -351,7 +351,7 @@ extern "C" {
     /// `true` in case all the pending envelopes have been sent within the timeout,
     /// or `false` if the timeout was hit.
     #[link_name = "sentry_transport_set_shutdown_func"]
-    pub fn transport_set_shutdown_func(transport: *mut Transport, shutdown_fn: ShutdownFunction);
+    pub fn transport_set_shutdown_func(transport: *mut Transport, shutdown_func: Option<ShutdownFunction>);
 
     /// Generic way to free a transport.
     #[link_name = "sentry_transport_free"]

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -120,6 +120,7 @@ pub enum UserConsent {
 /// its internal queue without shutting down, and to dump its internal queue to
 /// disk in case of a hard crash.
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Transport([u8; 0]);
 
 /// A Sentry Envelope.

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -14,6 +14,9 @@ use std::{
 #[allow(non_camel_case_types)]
 type c_wchar = u16;
 
+/// SDK Version
+pub const SDK_USER_AGENT: &str = "sentry.native/0.3.4";
+
 /// The Sentry Client Options.
 ///
 /// See <https://docs.sentry.io/error-reporting/configuration/>
@@ -99,10 +102,10 @@ pub enum UserConsent {
 /// This represents an interface for user-defined transports.
 ///
 /// Transports are responsible for sending envelopes to sentry and are the last
-/// step in the event pipeline. A transport has the following hooks, all of which
-/// take the user provided `state` as last parameter. The transport state needs
-/// to be set with `sentry_transport_set_state` and typically holds handles and
-/// other information that can be reused across requests.
+/// step in the event pipeline. A transport has the following hooks, all of
+/// which take the user provided `state` as last parameter. The transport state
+/// needs to be set with `sentry_transport_set_state` and typically holds
+/// handles and other information that can be reused across requests.
 ///
 /// * `send_func`: This function will take ownership of an envelope, and is
 ///   responsible for freeing it via `sentry_envelope_free`.
@@ -111,8 +114,8 @@ pub enum UserConsent {
 /// * `shutdown_func`: Instructs the transport to flush its queue and shut down.
 ///   This hook receives a millisecond-resolution `timeout` parameter and should
 ///   return `true` when the transport was flushed and shut down successfully.
-///   In case of `false`, sentry will log an error, but continue with freeing the
-///   transport.
+///   In case of `false`, sentry will log an error, but continue with freeing
+///   the transport.
 /// * `free_func`: Frees the transports `state`. This hook might be called even
 ///   though `shudown_func` returned `false` previously.
 ///
@@ -350,9 +353,9 @@ extern "C" {
 
     /// Sets the transport shutdown hook.
     ///
-    /// This hook will receive a millisecond-resolution timeout; it should return
-    /// `true` in case all the pending envelopes have been sent within the timeout,
-    /// or `false` if the timeout was hit.
+    /// This hook will receive a millisecond-resolution timeout; it should
+    /// return `true` in case all the pending envelopes have been sent
+    /// within the timeout, or `false` if the timeout was hit.
     #[link_name = "sentry_transport_set_shutdown_func"]
     pub fn transport_set_shutdown_func(
         transport: *mut Transport,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -31,7 +31,6 @@ impl CPath for PathBuf {
         #[cfg(windows)]
         let mut path: Vec<_> = self.into_os_string().encode_wide().collect();
         #[cfg(not(windows))]
-        #[allow(clippy::cast_possible_wrap)]
         let mut path: Vec<_> = self
             .into_os_string()
             .into_vec()

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -31,6 +31,7 @@ impl CPath for PathBuf {
         #[cfg(windows)]
         let mut path: Vec<_> = self.into_os_string().encode_wide().collect();
         #[cfg(not(windows))]
+        #[allow(clippy::cast_possible_wrap)]
         let mut path: Vec<_> = self
             .into_os_string()
             .into_vec()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ mod event;
 mod ffi;
 mod options;
 mod panic;
-#[cfg(feature = "custom-transport")]
 mod transport;
 mod user;
 mod value;
@@ -41,7 +40,11 @@ use std::{
 };
 use thiserror::Error;
 #[cfg(feature = "custom-transport")]
-pub use transport::{Dsn, PostedEnvelope, SentryRequest, Transport, TransportShutdown};
+pub use transport::{Dsn, Error as TransportError, Parts, Request};
+pub use transport::{
+    Envelope, RawEnvelope, Shutdown as TransportShutdown, Transport, API_VERSION, ENVELOPE_MIME,
+    SDK_USER_AGENT,
+};
 pub use user::User;
 pub use value::Value;
 
@@ -66,6 +69,10 @@ pub enum Error {
     /// List of fingerprints is too long.
     #[error("list of fingerprints is too long")]
     Fingerprints,
+    /// Failed at custom transport.
+    #[cfg(feature = "custom-transport")]
+    #[error("failed at custom transport")]
+    Transport(#[from] TransportError),
 }
 
 impl From<Infallible> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use ffi::{CPath, CToR, RToC};
 #[cfg(feature = "custom-transport")]
 pub use http;
 use object::{Map, Object};
-use options::{global_read, global_write, BEFORE_SEND};
+use options::{global_read, global_write, Ownership, BEFORE_SEND};
 pub use options::{BeforeSend, Options, Shutdown};
 pub use panic::set_hook;
 use std::{
@@ -41,9 +41,7 @@ use std::{
 };
 use thiserror::Error;
 #[cfg(feature = "custom-transport")]
-pub use transport::{
-    Dsn, PostedEnvelope, SentryRequest, Transport, TransportShutdown, TransportWorker,
-};
+pub use transport::{Dsn, PostedEnvelope, SentryRequest, Transport, TransportShutdown};
 pub use user::User;
 pub use value::Value;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ mod value;
 pub use breadcrumb::Breadcrumb;
 pub use event::{Event, Interface, Uuid};
 use ffi::{CPath, CToR, RToC};
+#[cfg(feature = "custom-transport")]
+pub use http;
 use object::{Map, Object};
 use options::{global_read, global_write, BEFORE_SEND};
 pub use options::{BeforeSend, Options, Shutdown};
@@ -38,6 +40,8 @@ use std::{
     ptr,
 };
 use thiserror::Error;
+#[cfg(feature = "custom-transport")]
+pub use transport::{SentryRequest, Transport, Transporter};
 pub use user::User;
 pub use value::Value;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,9 @@ use std::{
 };
 use thiserror::Error;
 #[cfg(feature = "custom-transport")]
-pub use transport::{SentryRequest, Transport, Transporter};
+pub use transport::{
+    Dsn, PostedEnvelope, SentryRequest, Transport, TransportShutdown, TransportWorker,
+};
 pub use user::User;
 pub use value::Value;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ mod event;
 mod ffi;
 mod options;
 mod panic;
+#[cfg(feature = "custom-transport")]
+mod transport;
 mod user;
 mod value;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,7 @@
 //! Sentry options implementation.
 
+#[cfg(feature = "custom-transport")]
+use crate::Transport;
 use crate::{CPath, CToR, Error, Level, RToC, Value};
 use once_cell::sync::{Lazy, OnceCell};
 #[cfg(feature = "test")]
@@ -140,17 +142,9 @@ impl Options {
     /// Sets a transport.
     ///
     /// # Examples
-    /// ```
-    /// # use sentry_contrib_native::{Options, Transport, SentryRequest};
-    /// let mut options = Options::new();
-    /// options.set_transport(Transport::new(Box::new(move |req: SentryRequest| {
-    ///     let (parts, body) = req.into_parts();
-    ///     println!("Sending request {:#?} to Sentry", parts);
-    ///     Ok(())
-    /// })));
-    /// ```
+    /// TODO
     #[cfg(feature = "custom-transport")]
-    pub fn set_transport(&mut self, transport: Box<crate::transport::Transport>) {
+    pub fn set_transport(&mut self, transport: Box<Transport>) {
         unsafe {
             sys::options_set_transport(self.as_mut(), transport.inner);
             // Sending in the transport passes ownership to Sentry, so we leak

--- a/src/options.rs
+++ b/src/options.rs
@@ -137,6 +137,11 @@ impl Options {
         self.raw.expect("use after free")
     }
 
+    #[cfg(feature = "custom-transport")]
+    pub fn set_transport(&mut self, transport: Box<Transport>) {
+        unsafe {}
+    }
+
     /// Sets the before send callback.
     ///
     /// # Examples

--- a/src/options.rs
+++ b/src/options.rs
@@ -137,9 +137,26 @@ impl Options {
         self.raw.expect("use after free")
     }
 
+    /// Sets a transport.
+    ///
+    /// # Examples
+    /// ```
+    /// # use sentry_contrib_native::{Options, Transport, SentryRequest};
+    /// let mut options = Options::new();
+    /// options.set_transport(Transport::new(Box::new(move |req: SentryRequest| {
+    ///     let (parts, body) = req.into_parts();
+    ///     println!("Sending request {:#?} to Sentry", parts);
+    ///     Ok(())
+    /// })));
+    /// ```
     #[cfg(feature = "custom-transport")]
-    pub fn set_transport(&mut self, transport: Box<Transport>) {
-        unsafe {}
+    pub fn set_transport(&mut self, transport: Box<crate::transport::Transport>) {
+        unsafe {
+            sys::options_set_transport(self.as_mut(), transport.inner);
+            // Sending in the transport passes ownership to Sentry, so we leak
+            // and let it call the appropriate startup/shutdown functions
+            Box::leak(transport);
+        }
     }
 
     /// Sets the before send callback.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -165,7 +165,7 @@ impl Transport {
     /// can come at any time.
     #[must_use]
     pub fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Box<Self> {
-        let inner = unsafe { sys::transport_new(Self::send_function) };
+        let inner = unsafe { sys::transport_new(Some(Self::send_function)) };
 
         unsafe {
             let ret = Box::new(Self {
@@ -176,9 +176,9 @@ impl Transport {
 
             let ptr = ret.into_raw();
             sys::transport_set_state(inner, ptr);
-            sys::transport_set_startup_hook(inner, Self::startup);
-            sys::transport_set_shutdown_func(inner, Self::shutdown);
-            sys::transport_set_free_func(inner, Self::free);
+            sys::transport_set_startup_func(inner, Some(Self::startup));
+            sys::transport_set_shutdown_func(inner, Some(Self::shutdown));
+            sys::transport_set_free_func(inner, Some(Self::free));
 
             Self::from_raw(ptr)
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,16 +4,56 @@
 //! itself.
 
 use crate::{Options, Ownership};
-use http::{HeaderValue, Request};
 use std::{
     mem::{self, ManuallyDrop},
-    os::raw::c_void,
+    os::raw::{c_char, c_void},
+    panic::{self, AssertUnwindSafe},
+    process, slice,
     time::Duration,
 };
-use sys::SDK_USER_AGENT;
+pub use sys::SDK_USER_AGENT;
+#[cfg(feature = "custom-transport")]
+use ::{
+    http::{HeaderValue, Request as HttpRequest},
+    std::{
+        convert::{Infallible, TryFrom},
+        str::FromStr,
+    },
+    thiserror::Error,
+    url::{ParseError, Url},
+};
 
-/// The request your [`TransportWorker`] is expected to send.
-pub type SentryRequest = Request<Envelope>;
+/// Sentry errors.
+#[cfg(feature = "custom-transport")]
+#[derive(Debug, Error, PartialEq)]
+pub enum Error {
+    /// Failed to parse DSN URL.
+    #[error("failed to parse DSN URL")]
+    UrlParse(#[from] ParseError),
+    /// DSN doesn't have a http(s) scheme.
+    #[error("DSN doesn't have a http(s) scheme")]
+    Scheme,
+    /// DSN has no username.
+    #[error("DSN has no username")]
+    Username,
+    /// DSN has no project ID.
+    #[error("DSN has no project ID")]
+    ProjectID,
+    /// DSN has no host.
+    #[error("DSN has no host")]
+    Host,
+}
+
+#[cfg(feature = "custom-transport")]
+impl From<Infallible> for Error {
+    fn from(from: Infallible) -> Self {
+        match from {}
+    }
+}
+
+/// The request your [`Transport`] is expected to send.
+#[cfg(feature = "custom-transport")]
+pub type Request = HttpRequest<Envelope>;
 
 /// The MIME type for Sentry envelopes.
 pub const ENVELOPE_MIME: &str = "application/x-sentry-envelope";
@@ -21,12 +61,11 @@ pub const ENVELOPE_MIME: &str = "application/x-sentry-envelope";
 /// hardcoded into sentry-native, so...two can play at that game!
 pub const API_VERSION: i8 = 7;
 
-/// The return from [`TransportWorker::shutdown`], which determines if we tell
+/// The return from [`Transport::shutdown`], which determines if we tell
 /// the Sentry SDK if we were able to send all requests to the remote service
 /// or not in the time allotted.
-#[allow(clippy::module_name_repetitions)]
-#[derive(Copy, Clone)]
-pub enum TransportShutdown {
+#[derive(Copy, Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Shutdown {
     /// The custom transport was able to send all requests in the time
     /// specified.
     Success,
@@ -34,25 +73,171 @@ pub enum TransportShutdown {
     TimedOut,
 }
 
+impl Shutdown {
+    /// Converts [`Shutdown`] into [`bool`].
+    fn into_raw(self) -> bool {
+        match self {
+            Self::Success => true,
+            Self::TimedOut => false,
+        }
+    }
+}
+
 /// Trait used to define your own transport that Sentry can use to send events
 /// to a Sentry service.
-pub trait Transport {
+pub trait Transport: 'static + Send + Sync {
     /// Starts up the transport worker, with the options that were used to
     /// create the Sentry SDK.
-    fn startup(&mut self, dsn: &Options);
+    #[allow(unused_variables)]
+    fn startup(&mut self, options: &Options) {}
 
     /// Sends the specified Envelope to a Sentry service.
     ///
     /// It is **highly** recommended to not block in this method, but rather
     /// to enqueue the worker to another thread.
-    fn send(&mut self, envelope: PostedEnvelope);
+    fn send(&mut self, envelope: RawEnvelope);
 
     /// Shuts down the transport worker. The worker should try to flush all
     /// of the pending requests to Sentry before shutdown. If the worker is
     /// successfully able to empty its queue and shutdown before the specified
-    /// timeout duration, it should return [`WorkerShutdown::Success`],
-    /// otherwise it should return [`WorkerShutdown::TimedOut`].
-    fn shutdown(&mut self, timeout: Duration) -> TransportShutdown;
+    /// timeout duration, it should return [`Shutdown::Success`],
+    /// otherwise it should return [`Shutdown::TimedOut`].
+    #[allow(unused_variables)]
+    fn shutdown(&mut self, timeout: Duration) -> Shutdown {
+        Shutdown::Success
+    }
+}
+
+impl<T: Fn(RawEnvelope) + 'static + Send + Sync> Transport for T {
+    fn send(&mut self, envelope: RawEnvelope) {
+        self(envelope)
+    }
+}
+
+/// The function registered with [`sys::transport_new`] when the SDK wishes
+/// to send an envelope to Sentry
+pub extern "C" fn send(envelope: *mut sys::Envelope, state: *mut c_void) {
+    let state = state as *mut Box<dyn Transport>;
+    let mut state = ManuallyDrop::new(unsafe { Box::from_raw(state) });
+    let envelope = RawEnvelope(envelope);
+
+    if panic::catch_unwind(AssertUnwindSafe(|| state.send(envelope))).is_err() {
+        process::abort()
+    }
+}
+
+/// The function registered with [`sys::transport_set_startup_func`] to
+/// start our transport so that we can being sending requests to Sentry
+pub extern "C" fn startup(options: *const sys::Options, state: *mut c_void) {
+    let state = state as *mut Box<dyn Transport>;
+    let mut state = ManuallyDrop::new(unsafe { Box::from_raw(state) });
+    let options = Options::from_sys(Ownership::Borrowed(options));
+
+    if panic::catch_unwind(AssertUnwindSafe(|| state.startup(&options))).is_err() {
+        process::abort()
+    }
+}
+
+/// The function registered with [`sys::transport_set_shutdown_func`] which
+/// will attempt to flush all of the outstanding requests via the transport,
+/// and shutdown the worker thread, before the specified timeout is reached
+pub extern "C" fn shutdown(timeout: u64, state: *mut c_void) -> bool {
+    let state = state as *mut Box<dyn Transport>;
+    let mut state = ManuallyDrop::new(unsafe { Box::from_raw(state) });
+    let timeout = Duration::from_millis(timeout);
+
+    match panic::catch_unwind(AssertUnwindSafe(|| state.shutdown(timeout))) {
+        Ok(shutdown) => shutdown.into_raw(),
+        Err(_) => process::abort(),
+    }
+}
+
+/// The function registered with [`sys::transport_set_free_func`] that
+/// actually frees our state
+pub extern "C" fn free(state: *mut c_void) {
+    let free = panic::catch_unwind(|| {
+        mem::drop(unsafe { Box::from_raw(state as *mut Box<dyn Transport>) })
+    });
+
+    if free.is_err() {
+        process::abort()
+    }
+}
+
+/// Wrapper for the raw Envelope that we should send to Sentry
+#[derive(Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+pub struct RawEnvelope(*mut sys::Envelope);
+
+unsafe impl Send for RawEnvelope {}
+unsafe impl Sync for RawEnvelope {}
+
+impl Drop for RawEnvelope {
+    fn drop(&mut self) {
+        unsafe { sys::envelope_free(self.0) }
+    }
+}
+
+impl RawEnvelope {
+    /// Serialize a [`RawEnvelope`] into an [`Envelope`].
+    #[must_use]
+    pub fn serialize(&self) -> Envelope {
+        let mut envelope_size = 0;
+        let serialized_envelope = unsafe { sys::envelope_serialize(self.0, &mut envelope_size) };
+
+        Envelope {
+            data: serialized_envelope,
+            len: envelope_size,
+        }
+    }
+
+    /// Constructs a HTTP request for the provided [`RawEnvelope`] with a
+    /// [`Dsn`].
+    ///
+    /// For more information see [`Envelope::into_request`].
+    #[cfg(feature = "custom-transport")]
+    #[must_use]
+    pub fn to_request(&self, dsn: Dsn) -> Request {
+        self.serialize().into_request(dsn)
+    }
+}
+
+/// The actual body which transports send to Sentry.
+#[derive(Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Envelope {
+    /// The raw bytes of the serialized envelope, which is the actual data to
+    /// send as the body of a request
+    data: *const c_char,
+    /// The length in bytes of the serialized data
+    len: usize,
+}
+
+unsafe impl Send for Envelope {}
+unsafe impl Sync for Envelope {}
+
+impl Drop for Envelope {
+    fn drop(&mut self) {
+        unsafe { sys::free(self.data as _) }
+    }
+}
+
+impl AsRef<[u8]> for Envelope {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Envelope {
+    /// Get underlying data as `[u8]`.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.data as _, self.len) }
+    }
+
+    /// Get underlying data as an owned `Vec<u8>`.
+    #[must_use]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
 
     /// Constructs a HTTP request for the provided [`sys::Envelope`] with the
     /// DSN that was registered with the SDK.
@@ -70,170 +255,69 @@ pub trait Transport {
     /// The `body` in the request is an [`Envelope`], which implements
     /// `AsRef<[u8]>` to retrieve the actual bytes that should be sent as the
     /// body.
-    ///
-    /// # Errors
-    /// Can fail if the envelope can't be serialized, or there is an invalid
-    /// header value.
+    #[cfg(feature = "custom-transport")]
     #[must_use]
-    fn convert_to_request(dsn: &Dsn, envelope: PostedEnvelope) -> SentryRequest
-    where
-        Self: Sized,
-    {
-        let mut builder = Request::builder()
+    pub fn into_request(self, dsn: Dsn) -> Request {
+        HttpRequest::builder()
             .header("user-agent", HeaderValue::from_static(SDK_USER_AGENT))
             .header("content-type", HeaderValue::from_static(ENVELOPE_MIME))
             .header("accept", HeaderValue::from_static("*/*"))
-            .method("POST");
-        builder = dsn.build_req(builder);
-
-        let envelope = Envelope::from(envelope);
-        builder = builder.header("content-length", envelope.as_ref().len());
-
-        builder.body(envelope).unwrap()
+            .method("POST")
+            .header("x-sentry-auth", dsn.auth)
+            .uri(dsn.url)
+            .header("content-length", self.as_bytes().len())
+            .body(self)
+            .unwrap()
     }
 }
 
-/// The function registered with [`sys::transport_new`] when the SDK wishes
-/// to send an envelope to Sentry
-pub extern "C" fn send(envelope: *mut sys::Envelope, state: *mut c_void) {
-    let state = state as *mut Box<dyn Transport>;
-    let mut state = ManuallyDrop::new(unsafe { Box::from_raw(state) });
-    let envelope = PostedEnvelope(envelope);
-
-    state.send(envelope);
-}
-
-/// The function registered with [`sys::transport_set_startup_func`] to
-/// start our transport so that we can being sending requests to Sentry
-pub extern "C" fn startup(options: *const sys::Options, state: *mut c_void) {
-    let state = state as *mut Box<dyn Transport>;
-    let mut state = ManuallyDrop::new(unsafe { Box::from_raw(state) });
-    let options = Options::from_sys(Ownership::Borrowed(options));
-
-    state.startup(&options);
-}
-
-/// The function registered with [`sys::transport_set_shutdown_func`] which
-/// will attempt to flush all of the outstanding requests via the transport,
-/// and shutdown the worker thread, before the specified timeout is reached
-pub extern "C" fn shutdown(timeout: u64, state: *mut c_void) -> bool {
-    let state = state as *mut Box<dyn Transport>;
-    let mut state = ManuallyDrop::new(unsafe { Box::from_raw(state) });
-    let timeout = Duration::from_millis(timeout);
-
-    match state.shutdown(timeout) {
-        TransportShutdown::Success => true,
-        TransportShutdown::TimedOut => false,
-    }
-}
-
-/// The function registered with [`sys::transport_set_free_func`] that
-/// actually frees our state
-pub extern "C" fn free(state: *mut c_void) {
-    mem::drop(unsafe { Box::from_raw(state as *mut Box<dyn Transport>) });
-}
-
-/// Wrapper for the raw Envelope that we should send to Sentry
-pub struct PostedEnvelope(*mut sys::Envelope);
-
-unsafe impl Send for PostedEnvelope {}
-
-impl Drop for PostedEnvelope {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            unsafe {
-                sys::envelope_free(self.0);
-                self.0 = std::ptr::null_mut();
-            }
-        }
-    }
-}
-
-/// The actual body which transports send to Sentry.
-pub struct Envelope {
-    /// The raw bytes of the serialized envelope, which is the actual data to
-    /// send as the body of a request
-    data: *const std::os::raw::c_char,
-    /// The length in bytes of the serialized data
-    len: usize,
-}
-
-unsafe impl Send for Envelope {}
-
-impl AsRef<[u8]> for Envelope {
-    fn as_ref(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.data as *const _, self.len) }
-    }
-}
-
-impl Drop for Envelope {
-    fn drop(&mut self) {
-        if !self.data.is_null() {
-            unsafe {
-                sys::free(self.data as *mut _);
-                self.data = std::ptr::null();
-            }
-        }
-    }
-}
-
-impl From<PostedEnvelope> for Envelope {
-    fn from(pe: PostedEnvelope) -> Self {
-        unsafe {
-            let mut envelope_size = 0;
-            let serialized_envelope = sys::envelope_serialize(pe.0, &mut envelope_size);
-
-            Self {
-                data: serialized_envelope,
-                len: envelope_size,
-            }
-        }
+impl From<RawEnvelope> for Envelope {
+    fn from(value: RawEnvelope) -> Self {
+        value.serialize()
     }
 }
 
 /// Contains the pieces we need to send requests based on the DSN the user
 /// set on [`Options`]
+#[cfg(feature = "custom-transport")]
+#[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Dsn {
     /// The auth header value
-    pub auth: String,
+    auth: String,
     /// The full URI to send envelopes to
-    pub uri: String,
+    url: String,
 }
 
+#[cfg(feature = "custom-transport")]
 impl Dsn {
-    /// Adds the URI and auth header to the request
-    #[inline]
-    fn build_req(&self, mut rb: http::request::Builder) -> http::request::Builder {
-        rb = rb.header("x-sentry-auth", &self.auth);
-        rb.uri(&self.uri)
-    }
-}
-
-impl std::str::FromStr for Dsn {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    /// Creates a new [`Dsn`] from a [`str`].
+    ///
+    /// # Errors
+    /// Fails with [`Error::Transport`](crate::Error::Transport) if the DSN is
+    /// invalid.
+    pub fn new(dsn: &str) -> Result<Self, crate::Error> {
         // A sentry DSN contains the following components:
         // <https://<username>@<host>/<path>>
         // * username = public key
         // * host = obviously, the host, sentry.io in the case of the hosted service
         // * path = the project ID
-        let dsn_url = url::Url::parse(s).map_err(|_| "failed to parse DSN url")?;
+        let dsn_url = Url::parse(dsn).map_err(Error::from)?;
 
         // Do some basic checking that the DSN is remotely valid
         if !dsn_url.scheme().starts_with("http") {
-            return Err("DSN doesn't have an http(s) scheme");
+            return Err(Error::Scheme.into());
         }
 
         if dsn_url.username().is_empty() {
-            return Err("DSN has no username");
+            return Err(Error::Username.into());
         }
 
         if dsn_url.path().is_empty() || dsn_url.path() == "/" {
-            return Err("DSN doesn't have a path");
+            return Err(Error::ProjectID.into());
         }
 
         match dsn_url.host_str() {
+            None => Err(Error::Host.into()),
             Some(host) => {
                 let auth = format!(
                     "Sentry sentry_key={}, sentry_version={}, sentry_client={}",
@@ -242,55 +326,110 @@ impl std::str::FromStr for Dsn {
                     SDK_USER_AGENT
                 );
 
-                let uri = format!(
+                let url = format!(
                     "{}://{}/api/{}/envelope/",
                     dsn_url.scheme(),
                     host,
                     &dsn_url.path()[1..]
                 );
 
-                Ok(Self { auth, uri })
+                Ok(Self { auth, url })
             }
-            None => Err("DSN doesn't have a host"),
+        }
+    }
+
+    /// The auth header value
+    #[must_use]
+    pub fn auth(&self) -> &str {
+        &self.auth
+    }
+
+    /// The full URL to send envelopes to
+    #[must_use]
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Consume [`Dsn`] and return it's parts.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn into_parts(self) -> Parts {
+        Parts {
+            auth: self.auth,
+            url: self.url,
         }
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
+#[cfg(feature = "custom-transport")]
+impl FromStr for Dsn {
+    type Err = crate::Error;
 
-    #[test]
-    fn parses_dsn() {
-        {
-            let hosted =
-                "https://a0b1c2d3e4f5678910abcdeffedcba12@o209016.ingest.sentry.io/0123456";
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
 
-            let mut builder = http::Request::builder();
-            let dsn: Dsn = hosted.parse().expect("failed to parse hosted DSN");
-            builder = dsn.build_req(builder);
+#[cfg(feature = "custom-transport")]
+impl TryFrom<&str> for Dsn {
+    type Error = crate::Error;
 
-            assert_eq!(
-                builder.uri_ref().unwrap(),
-                "https://o209016.ingest.sentry.io/api/0123456/envelope/"
-            );
-            let headers = builder.headers_ref().unwrap();
-            assert_eq!(headers.get("x-sentry-auth").unwrap(), &format!("Sentry sentry_key=a0b1c2d3e4f5678910abcdeffedcba12, sentry_version={}, sentry_client={}", API_VERSION, SDK_USER_AGENT));
-        }
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
 
-        {
-            let private = "http://a0b1c2d3e4f5678910abcdeffedcba12@192.168.1.1/0123456";
+/// [`Parts`] aquired from [`Dsn::into_parts`].
+#[cfg(feature = "custom-transport")]
+#[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Parts {
+    /// The auth header value
+    pub auth: String,
+    /// The full URI to send envelopes to
+    pub url: String,
+}
 
-            let mut builder = http::Request::builder();
-            let dsn: Dsn = private.parse().expect("failed to parse hosted DSN");
-            builder = dsn.build_req(builder);
+#[cfg(all(test, feature = "custom-transport"))]
+#[rusty_fork::test_fork]
+fn dsn() -> anyhow::Result<()> {
+    use crate::Event;
 
-            assert_eq!(
-                builder.uri_ref().unwrap(),
-                "http://192.168.1.1/api/0123456/envelope/"
-            );
-            let headers = builder.headers_ref().unwrap();
-            assert_eq!(headers.get("x-sentry-auth").unwrap(), &format!("Sentry sentry_key=a0b1c2d3e4f5678910abcdeffedcba12, sentry_version={}, sentry_client={}", API_VERSION, SDK_USER_AGENT));
+    struct Parser;
+
+    impl Transport for Parser {
+        fn send(&mut self, envelope: RawEnvelope) {
+            {
+                let dsn = Dsn::new(
+                    "https://a0b1c2d3e4f5678910abcdeffedcba12@o209016.ingest.sentry.io/0123456",
+                )
+                .unwrap();
+                let request = envelope.to_request(dsn);
+
+                assert_eq!(
+                    request.uri(),
+                    "https://o209016.ingest.sentry.io/api/0123456/enveloper/"
+                );
+                let headers = request.headers();
+                assert_eq!(headers.get("x-sentry-auth").unwrap(), &format!("Sentry sentry_key=a0b1c2d3e4f5678910abcdeffedcba12, sentry_version={}, sentry_client={}", API_VERSION, SDK_USER_AGENT));
+            }
+
+            {
+                let dsn = Dsn::new("http://a0b1c2d3e4f5678910abcdeffedcba12@192.168.1.1/0123456")
+                    .unwrap();
+                let request = envelope.to_request(dsn);
+
+                assert_eq!(request.uri(), "http://192.168.1.1/api/0123456/envelope/");
+                let headers = request.headers();
+                assert_eq!(headers.get("x-sentry-auth").unwrap(), &format!("Sentry sentry_key=a0b1c2d3e4f5678910abcdeffedcba12, sentry_version={}, sentry_client={}", API_VERSION, SDK_USER_AGENT));
+            }
         }
     }
+
+    let mut options = Options::new();
+    options.set_transport(Parser);
+    let _shutdown = options.init();
+
+    Event::new().capture();
+
+    Ok(())
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -89,9 +89,7 @@ pub trait TransportWorker {
         let envelope = Envelope::try_from(envelope)?;
         builder = builder.header("content-length", envelope.as_ref().len());
 
-        builder
-            .body(envelope)
-            .map_err(|_| "failed to build HTTP request")
+        builder.body(envelope).unwrap()
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -77,25 +77,10 @@ pub trait TransportWorker {
         let mut builder = http::Request::builder();
 
         {
-            let headers = builder
-                .headers_mut()
-                .ok_or_else(|| "unable to mutate headers")?;
-            headers.insert(
-                "user-agent",
-                USER_AGENT
-                    .parse()
-                    .map_err(|_| "failed to parse user agent")?,
-            );
-            headers.insert(
-                "content-type",
-                ENVELOPE_MIME
-                    .parse()
-                    .map_err(|_| "failed to parse MIME type")?,
-            );
-            headers.insert(
-                "accept",
-                "*/*".parse().map_err(|_| "failed to parse accept")?,
-            );
+            let headers = builder.headers_mut().unwrap();
+            headers.insert("user-agent", USER_AGENT.parse().unwrap());
+            headers.insert("content-type", ENVELOPE_MIME.parse().unwrap());
+            headers.insert("accept", "*/*".parse().unwrap());
         }
 
         builder = builder.method("POST");

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,7 +4,7 @@
 
 use std::{convert::TryFrom, os::raw::c_void};
 
-/// The request your [`Transporter`] is expected to send.
+/// The request your [`TransportWorker`] is expected to send.
 pub type SentryRequest = http::Request<Envelope>;
 
 /// From sentry.h, but only present as a preprocessor define :(
@@ -104,9 +104,8 @@ pub struct Transport {
 }
 
 impl Transport {
-    /// Creates a new Transport for Sentry using your provided [`Transporter`]
-    /// implementation. It's required to by [`Send`] and [`Sync`] as requests
-    /// can come at any time.
+    /// Creates a new Transport for Sentry using your provided [`TransportWorker`]
+    /// implementation.
     #[must_use]
     pub fn new(worker: Box<dyn TransportWorker>) -> Box<Self> {
         let inner = unsafe { sys::transport_new(Some(Self::send_function)) };

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,145 +1,295 @@
+//! Contains types for creating custom transports that the underlying sentry-native
+//! library can use to send data to your upstream Sentry service in lieue of
+//! the built-in transports provided by the sentry-native library itself
+
 use std::{
     os::raw::c_void,
     sync::{mpsc, Arc, Condvar, Mutex},
 };
 
-/// Trait used to define your own transpor that Sentry can use to send events
+/// The request your [`Transporter`] is expected to send.
+pub type SentryRequest = http::Request<Envelope>;
+
+/// Trait used to define your own transport that Sentry can use to send events
 /// to a Sentry service
 pub trait Transporter {
-    fn send(&self, request: http::Request<Envelope>);
+    /// Method called when Sentry wishes to send data to a Sentry service
+    ///
+    /// The request contains all of the necessary pieces of data
+    /// * The uri to send the request to
+    /// * The headers that must be set
+    /// * The body of the request
+    ///
+    /// The `content-length` header is already set for you, though some HTTP
+    /// clients will automatically set it for you in some cases, which should
+    /// be fine.
+    ///
+    /// The `body` in the request is a [`Envelope`], which implements `AsRef<[u8]`
+    /// to retrieve the actual bytes that should be sent as the body
+    ///
+    /// # Errors
+    /// If your [`Transporter`] is unable to send the request, it can return
+    /// an error if it wishes. This error will be printed out to stderr if
+    /// you have enabled debugging in [`Options`]
+    fn send(&self, request: SentryRequest) -> Result<(), &'static str>;
 }
 
 impl<F> Transporter for F
 where
-    F: Fn(http::Request<Envelope>) + Send + Sync,
+    F: Fn(SentryRequest) -> Result<(), &'static str> + Send + Sync,
 {
-    fn send(&self, request: http::Request<Envelope>) {
+    fn send(&self, request: SentryRequest) -> Result<(), &'static str> {
         self(request)
     }
 }
 
+/// Wrapper around the raw pointer so that we can mark it as Send so that we
+/// postpone any actual work to the worker thread
+struct PostedEnvelope(*mut sys::Envelope);
+
+unsafe impl Send for PostedEnvelope {}
+
+/// Sentry internally uses a simple background thread worker to do the actual
+/// work of sending requests for the provided transports, so we do as well
 struct Worker {
-    tx: mpsc::Sender<*mut sys::Envelope>,
+    /// Sender we use to enqueue work to the background thread
+    tx: mpsc::Sender<PostedEnvelope>,
+    /// Condition variable we use to detect when the background thread has been
+    /// shutdown
+    shutdown: Arc<(Mutex<()>, Condvar)>,
+    /// True if the user specified they want debug information from the SDK
+    debug: bool,
 }
 
 impl Worker {
-    fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Self {
-        let (tx, rx) = mpsc::channel();
-        let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
+    /// Creates a new worker which spins up a thread to handle sending requests
+    /// to Sentry
+    fn new(debug: bool, dsn: Dsn, transporter: Box<dyn Transporter + Send + Sync>) -> Self {
+        let (tx, rx) = mpsc::channel::<PostedEnvelope>();
+        let shutdown = Arc::new((Mutex::new(()), Condvar::new()));
         let tshutdown = shutdown.clone();
 
-        let handle = std::thread::spawn(move || {
+        if debug {
+            eprintln!("[sentry-contrib-native]: Starting up worker thread");
+        }
+
+        std::thread::spawn(move || {
             while let Ok(envelope) = rx.recv() {
+                let envelope = envelope.0;
+
                 // We don't protect against panics here, but maybe that should
                 // be an option?
-                match construct_request(envelope) {
+                match construct_request(envelope, &dsn) {
                     Ok(request) => {
-                        transporter.send(request);
+                        if debug {
+                            eprintln!(
+                                "[sentry-contrib-native]: Sending envelope {} {:#?}",
+                                request.uri(),
+                                request.headers(),
+                            );
+                        }
+
+                        let res = transporter.send(request);
+
+                        if debug {
+                            match res {
+                                Ok(_) => {
+                                    eprintln!("[sentry-contrib-native]: Successfully sent envelope")
+                                }
+                                Err(err) => eprintln!(
+                                    "[sentry-contrib-native]: Failed to send envelope: {}",
+                                    err
+                                ),
+                            }
+                        }
                     }
                     Err(_) => unsafe { sys::envelope_free(envelope) },
                 }
             }
 
             let (lock, cvar) = &*tshutdown;
-            let mut shutdown = lock.lock().unwrap();
-            *shutdown = true;
+            let _shutdown = lock.lock().unwrap();
             cvar.notify_one();
         });
 
-        Self { tx, shutdown }
+        Self {
+            debug,
+            tx,
+            shutdown,
+        }
     }
 
+    /// Enqueues an envelope to be sent via the user's [`Transporter`]
     fn enqueue(&self, envelope: *mut sys::Envelope) {
-        self.tx.send(envelope).expect("failed to enqueue envelope");
+        self.tx
+            .send(PostedEnvelope(envelope))
+            .expect("failed to enqueue envelope");
     }
 
+    /// Shuts down the worker and waits for it be shutdown up to the specified
+    /// time. Returns `true` if the timeout is reached before the worker has
+    /// been fully shutdown.
     fn shutdown(self, timeout: std::time::Duration) -> bool {
+        if self.debug {
+            eprintln!("[sentry-contrib-native]: Shutting down worker thread");
+        }
+
+        // Drop the sender so that the background thread will exit once
+        // it has dequeued and processed all the envelopes we have enqueued
         drop(self.tx);
 
+        // Wait for the condition variable to notify that the thread has shutdown
         let (lock, cvar) = &*self.shutdown;
-        let mut shutdown = lock.lock().unwrap();
+        let shutdown = lock.lock().unwrap();
         let result = cvar.wait_timeout(shutdown, timeout).unwrap();
 
         result.1.timed_out()
     }
 }
 
+/// Holds the state for your custom transport. The lifetime of this state is
+/// handled by the underlying Sentry library, which is why you only get a `Box<>`
 pub struct Transport {
-    inner: *mut sys::Transport,
+    /// The inner transport that our state is attached to
+    pub(crate) inner: *mut sys::Transport,
+    /// The user's [`Transporter`] implementation, moved to the background
+    /// worker on startup
     user_impl: Option<Box<dyn Transporter + Send + Sync>>,
+    /// Our background worker
     worker: Option<Worker>,
 }
 
 impl Transport {
+    /// Creates a new Transport for Sentry using your provided [`Transporter`]
+    /// implementation. It's required to by [`Send`] and [`Sync`] as requests
+    /// can come at any time.
+    #[must_use]
     pub fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Box<Self> {
         let inner = unsafe { sys::transport_new(Self::send_function) };
 
-        let ret = Box::new(Self {
-            inner,
-            user_impl: transporter,
-            worker: None,
-        });
-
         unsafe {
-            sys::transport_set_state(inner, ret.as_ref().as_ptr() as *mut _);
-            sys::transport_set_startup_hook(inner, Self::startup);
-            sys::transport_set_shutdown_hook(inner, Self::shutdown);
-        }
+            let ret = Box::new(Self {
+                inner,
+                user_impl: Some(transporter),
+                worker: None,
+            });
 
-        ret
+            let ptr = ret.into_raw();
+            sys::transport_set_state(inner, ptr);
+            sys::transport_set_startup_hook(inner, Self::startup);
+            sys::transport_set_shutdown_func(inner, Self::shutdown);
+            sys::transport_set_free_func(inner, Self::free);
+
+            Self::from_raw(ptr)
+        }
     }
 
-    pub(crate) fn into_raw(self: Box<Self>) -> *mut c_void {
+    /// Convert ourselves into a state pointer, and prevents deallocating
+    #[inline]
+    fn into_raw(self: Box<Self>) -> *mut c_void {
         Box::into_raw(self) as *mut _
     }
 
-    pub(crate) fn from_raw(state: *mut c_void) -> Box<Self> {
+    /// Convert a state pointer back into a Box
+    #[inline]
+    fn from_raw(state: *mut c_void) -> Box<Self> {
         unsafe { Box::from_raw(state as *mut _) }
     }
 
-    fn send_function(envelope: *mut Envelope, state: *mut c_void) {
-        let self = Self::from_raw(state);
-        if let Some(q) = &self.queue {
+    /// The function registered with [`sys::transport_new`] when the SDK wishes
+    /// to send an envelope to Sentry
+    extern "C" fn send_function(envelope: *mut sys::Envelope, state: *mut c_void) {
+        let s = Self::from_raw(state);
+        if let Some(q) = &s.worker {
             q.enqueue(envelope);
         }
-        Self::into_raw(self);
+        s.into_raw();
     }
 
-    fn startup(options: *const sys::Options, state: *mut c_void) {
-        let self = Self::from_raw(state);
+    /// The function registered with [`sys::transport_set_startup_hook`] to
+    /// start our transport so that we can being sending requests to Sentry
+    extern "C" fn startup(options: *const sys::Options, state: *mut c_void) {
+        let mut s = Self::from_raw(state);
 
-        match self.user_impl.take() {
-            Some(imp) => self.worker = Some(Worker::new(imp)),
-            None => {}
+        if let Some(imp) = s.user_impl.take() {
+            unsafe {
+                let dsn = sys::options_get_dsn(options);
+                let debug = sys::options_get_debug(options) == 1;
+
+                if dsn.is_null() {
+                    if debug {
+                        eprintln!("[sentry-contrib-native]: DSN is null");
+                    }
+
+                    s.into_raw();
+                    return;
+                }
+
+                let dsn = std::ffi::CStr::from_ptr(dsn);
+
+                match dsn.to_str() {
+                    Ok(dsn_url) => match dsn_url.parse() {
+                        Ok(dsn) => {
+                            s.worker = Some(Worker::new(debug, dsn, imp));
+                        }
+                        Err(err) => {
+                            if debug {
+                                eprintln!("[sentry-contrib-native]: Failed to parse DSN: {}", err);
+                            }
+                        }
+                    },
+                    Err(err) => {
+                        if debug {
+                            eprintln!(
+                                "[sentry-contrib-native]: DSN url has invalid UTF-8: {}",
+                                err
+                            );
+                        }
+                    }
+                }
+            }
         }
 
-        self.into_raw()
+        s.into_raw();
     }
 
-    fn shutdown(timeout: u64, state: *mut c_void) -> bool {
-        let self = Self::from_raw(state);
+    /// The function registered with [`sys::transport_set_shutdown_func`] which
+    /// will attempt to flush all of the outstanding requests via the transport,
+    /// and shutdown the worker thread, before the specified timeout is reached
+    extern "C" fn shutdown(timeout: u64, state: *mut c_void) -> bool {
+        let mut s = Self::from_raw(state);
 
-        let sent_all = match self.worker.take() {
-            Some(worker) => !worker.shutdown(),
+        let sent_all = match s.worker.take() {
+            Some(worker) => !worker.shutdown(std::time::Duration::from_millis(timeout)),
             None => true,
         };
 
-        self.into_raw();
+        s.into_raw();
 
         sent_all
+    }
+
+    /// The function registered with [`sys::transport_set_free_func`] that
+    /// actually frees
+    extern "C" fn free(state: *mut c_void) {
+        let mut s = Self::from_raw(state);
+        s.inner = std::ptr::null_mut();
     }
 }
 
 impl Drop for Transport {
     fn drop(&mut self) {
         unsafe {
-            sys::transport_free(self.inner);
+            if !self.inner.is_null() {
+                sys::transport_free(self.inner);
+            }
         }
     }
 }
 
 /// From sentry.h, but only present as a preprocessor define :(
 const USER_AGENT: &str = "sentry.native/0.3.2";
+/// The MIME type for Sentry envelopes
 const ENVELOPE_MIME: &str = "application/x-sentry-envelope";
 /// Version of the Sentry API we can communicate with, AFAICT this is just
 /// hardcoded into sentry-native, so...two can play at that game!
@@ -147,10 +297,16 @@ const API_VERSION: i8 = 7;
 
 /// The actual body which transports send to Sentry.
 pub struct Envelope {
+    /// The underlying opaque pointer. Freed once we are finished with the envelope.
     inner: *mut sys::Envelope,
+    /// The raw bytes of the serialized envelope, which is the actual data to
+    /// send as the body of a request
     data: *const std::os::raw::c_char,
+    /// The length in bytes of the serialized data
     len: usize,
 }
+
+unsafe impl Send for Envelope {}
 
 impl AsRef<[u8]> for Envelope {
     fn as_ref(&self) -> &[u8] {
@@ -167,9 +323,77 @@ impl Drop for Envelope {
     }
 }
 
-fn construct_request(envelope: *mut sys::Envelope) -> Result<http::Request<Envelope>, ()> {
-    use std::ffi::CStr;
+/// Contains the pieces we need to send requests based on the DSN the user
+/// set on [`Options`]
+struct Dsn {
+    /// The auth header value
+    auth: String,
+    /// The full URI to send envelopes to
+    uri: String,
+}
 
+impl Dsn {
+    /// Adds the URI and auth header to the request
+    #[inline]
+    fn build_req(&self, mut rb: http::request::Builder) -> http::request::Builder {
+        rb = rb.header("x-sentry-auth", &self.auth);
+        rb.uri(&self.uri)
+    }
+}
+
+impl std::str::FromStr for Dsn {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // A sentry DSN contains the following components:
+        // <https://<username>@<host>/<path>>
+        // * username = public key
+        // * host = obviously, the host, sentry.io in the case of the hosted service
+        // * path = the project ID
+        let url = url::Url::parse(s).map_err(|_| "failed to parse DSN url")?;
+
+        // Do some basic checking that the DSN is remotely valid
+        if !url.scheme().starts_with("http") {
+            return Err("DSN doesn't have an http(s) scheme");
+        }
+
+        if url.username().is_empty() {
+            return Err("DSN has no username");
+        }
+
+        if url.path().is_empty() || url.path() == "/" {
+            return Err("DSN doesn't have a path");
+        }
+
+        match url.host_str() {
+            Some(host) => {
+                let auth = format!(
+                    "Sentry sentry_key={}, sentry_version={}, sentry_client={}",
+                    url.username(),
+                    API_VERSION,
+                    USER_AGENT
+                );
+
+                let uri = format!(
+                    "{}://{}/api/{}/envelope/",
+                    url.scheme(),
+                    host,
+                    &url.path()[1..]
+                );
+
+                Ok(Self { auth, uri })
+            }
+            None => Err("DSN doesn't have a host"),
+        }
+    }
+}
+
+/// Constructs an HTTP request for the provided [`sys::Envelope`] with the DSN
+/// that was registered with the SDK
+fn construct_request(
+    envelope: *mut sys::Envelope,
+    dsn: &Dsn,
+) -> Result<http::Request<Envelope>, ()> {
     let mut builder = http::Request::builder();
 
     {
@@ -180,26 +404,10 @@ fn construct_request(envelope: *mut sys::Envelope) -> Result<http::Request<Envel
     }
 
     builder = builder.method("POST");
+    builder = dsn.build_req(builder);
 
     // Get the DSN for the options, which informs us where to send the request, and what auth token to use
     let envelope = unsafe {
-        let opts = sys::get_options();
-
-        if opts.is_null() {
-            return Err(());
-        }
-
-        let dsn = sys::options_get_dsn(opts);
-
-        if dsn.is_null() {
-            return Err(());
-        }
-
-        let dsn = CStr::from_ptr(dsn);
-        let dsn_url = dsn.to_str().map_err(|_| ())?;
-
-        builder = from_dsn(builder, dsn_url)?;
-
         let mut envelope_size = 0;
         let serialized_envelope = sys::envelope_serialize(envelope, &mut envelope_size);
 
@@ -210,53 +418,13 @@ fn construct_request(envelope: *mut sys::Envelope) -> Result<http::Request<Envel
         builder = builder.header("content-length", envelope_size);
 
         Envelope {
-            inner: serialized_envelope,
+            inner: envelope,
+            data: serialized_envelope,
             len: envelope_size,
         }
     };
 
     builder.body(envelope).map_err(|_| ())
-}
-
-fn from_dsn(
-    mut builder: http::request::Builder,
-    dsn_url: &str,
-) -> Result<http::request::Builder, ()> {
-    // A sentry DSN contains the following components:
-    // <https://<username>@<host>/<path>>
-    // * username = public key
-    // * host = obviously, the host, sentry.io in the case of the hosted service
-    // * path = the project ID
-    let url = url::Url::parse(dsn_url).map_err(|_| ())?;
-
-    // Do some basic checking that the DSN is remotely valid
-    if !url.scheme().starts_with("http")
-        || url.username().is_empty()
-        || !url.has_host()
-        || url.path().is_empty()
-        || url.path() == "/"
-    {
-        return Err(());
-    }
-
-    builder = builder.header(
-        "x-sentry-auth",
-        format!(
-            "Sentry sentry_key={}, sentry_version={}, sentry_client={}",
-            url.username(),
-            API_VERSION,
-            USER_AGENT
-        ),
-    );
-
-    builder = builder.uri(format!(
-        "{}://{}/api/{}/envelope/",
-        url.scheme(),
-        url.host_str().expect("DSN didn't contain a host"),
-        &url.path()[1..]
-    ));
-
-    Ok(builder)
 }
 
 #[cfg(test)]
@@ -270,7 +438,8 @@ mod test {
                 "https://a0b1c2d3e4f5678910abcdeffedcba12@o209016.ingest.sentry.io/0123456";
 
             let mut builder = http::Request::builder();
-            builder = from_dsn(builder, hosted).expect("failed to parse hosted URL");
+            let dsn: Dsn = hosted.parse().expect("failed to parse hosted DSN");
+            builder = dsn.build_req(builder);
 
             assert_eq!(
                 builder.uri_ref().unwrap(),
@@ -284,7 +453,8 @@ mod test {
             let private = "http://a0b1c2d3e4f5678910abcdeffedcba12@192.168.1.1/0123456";
 
             let mut builder = http::Request::builder();
-            builder = from_dsn(builder, private).expect("failed to parse private URL");
+            let dsn: Dsn = private.parse().expect("failed to parse hosted DSN");
+            builder = dsn.build_req(builder);
 
             assert_eq!(
                 builder.uri_ref().unwrap(),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,297 @@
+use std::{
+    os::raw::c_void,
+    sync::{mpsc, Arc, Condvar, Mutex},
+};
+
+/// Trait used to define your own transpor that Sentry can use to send events
+/// to a Sentry service
+pub trait Transporter {
+    fn send(&self, request: http::Request<Envelope>);
+}
+
+impl<F> Transporter for F
+where
+    F: Fn(http::Request<Envelope>) + Send + Sync,
+{
+    fn send(&self, request: http::Request<Envelope>) {
+        self(request)
+    }
+}
+
+struct Worker {
+    tx: mpsc::Sender<*mut sys::Envelope>,
+}
+
+impl Worker {
+    fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
+        let tshutdown = shutdown.clone();
+
+        let handle = std::thread::spawn(move || {
+            while let Ok(envelope) = rx.recv() {
+                // We don't protect against panics here, but maybe that should
+                // be an option?
+                match construct_request(envelope) {
+                    Ok(request) => {
+                        transporter.send(request);
+                    }
+                    Err(_) => unsafe { sys::envelope_free(envelope) },
+                }
+            }
+
+            let (lock, cvar) = &*tshutdown;
+            let mut shutdown = lock.lock().unwrap();
+            *shutdown = true;
+            cvar.notify_one();
+        });
+
+        Self { tx, shutdown }
+    }
+
+    fn enqueue(&self, envelope: *mut sys::Envelope) {
+        self.tx.send(envelope).expect("failed to enqueue envelope");
+    }
+
+    fn shutdown(self, timeout: std::time::Duration) -> bool {
+        drop(self.tx);
+
+        let (lock, cvar) = &*self.shutdown;
+        let mut shutdown = lock.lock().unwrap();
+        let result = cvar.wait_timeout(shutdown, timeout).unwrap();
+
+        result.1.timed_out()
+    }
+}
+
+pub struct Transport {
+    inner: *mut sys::Transport,
+    user_impl: Option<Box<dyn Transporter + Send + Sync>>,
+    worker: Option<Worker>,
+}
+
+impl Transport {
+    pub fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Box<Self> {
+        let inner = unsafe { sys::transport_new(Self::send_function) };
+
+        let ret = Box::new(Self {
+            inner,
+            user_impl: transporter,
+            worker: None,
+        });
+
+        unsafe {
+            sys::transport_set_state(inner, ret.as_ref().as_ptr() as *mut _);
+            sys::transport_set_startup_hook(inner, Self::startup);
+            sys::transport_set_shutdown_hook(inner, Self::shutdown);
+        }
+
+        ret
+    }
+
+    pub(crate) fn into_raw(self: Box<Self>) -> *mut c_void {
+        Box::into_raw(self) as *mut _
+    }
+
+    pub(crate) fn from_raw(state: *mut c_void) -> Box<Self> {
+        unsafe { Box::from_raw(state as *mut _) }
+    }
+
+    fn send_function(envelope: *mut Envelope, state: *mut c_void) {
+        let self = Self::from_raw(state);
+        if let Some(q) = &self.queue {
+            q.enqueue(envelope);
+        }
+        Self::into_raw(self);
+    }
+
+    fn startup(options: *const sys::Options, state: *mut c_void) {
+        let self = Self::from_raw(state);
+
+        match self.user_impl.take() {
+            Some(imp) => self.worker = Some(Worker::new(imp)),
+            None => {}
+        }
+
+        self.into_raw()
+    }
+
+    fn shutdown(timeout: u64, state: *mut c_void) -> bool {
+        let self = Self::from_raw(state);
+
+        let sent_all = match self.worker.take() {
+            Some(worker) => !worker.shutdown(),
+            None => true,
+        };
+
+        self.into_raw();
+
+        sent_all
+    }
+}
+
+impl Drop for Transport {
+    fn drop(&mut self) {
+        unsafe {
+            sys::transport_free(self.inner);
+        }
+    }
+}
+
+/// From sentry.h, but only present as a preprocessor define :(
+const USER_AGENT: &str = "sentry.native/0.3.2";
+const ENVELOPE_MIME: &str = "application/x-sentry-envelope";
+/// Version of the Sentry API we can communicate with, AFAICT this is just
+/// hardcoded into sentry-native, so...two can play at that game!
+const API_VERSION: i8 = 7;
+
+/// The actual body which transports send to Sentry.
+pub struct Envelope {
+    inner: *mut sys::Envelope,
+    data: *const std::os::raw::c_char,
+    len: usize,
+}
+
+impl AsRef<[u8]> for Envelope {
+    fn as_ref(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.data as *const _, self.len) }
+    }
+}
+
+impl Drop for Envelope {
+    fn drop(&mut self) {
+        unsafe {
+            sys::free(self.data as *mut _);
+            sys::envelope_free(self.inner);
+        }
+    }
+}
+
+fn construct_request(envelope: *mut sys::Envelope) -> Result<http::Request<Envelope>, ()> {
+    use std::ffi::CStr;
+
+    let mut builder = http::Request::builder();
+
+    {
+        let headers = builder.headers_mut().expect("unable to mutate headers");
+        headers.insert("user-agent", USER_AGENT.parse().unwrap());
+        headers.insert("content-type", ENVELOPE_MIME.parse().unwrap());
+        headers.insert("accept", "*/*".parse().unwrap());
+    }
+
+    builder = builder.method("POST");
+
+    // Get the DSN for the options, which informs us where to send the request, and what auth token to use
+    let envelope = unsafe {
+        let opts = sys::get_options();
+
+        if opts.is_null() {
+            return Err(());
+        }
+
+        let dsn = sys::options_get_dsn(opts);
+
+        if dsn.is_null() {
+            return Err(());
+        }
+
+        let dsn = CStr::from_ptr(dsn);
+        let dsn_url = dsn.to_str().map_err(|_| ())?;
+
+        builder = from_dsn(builder, dsn_url)?;
+
+        let mut envelope_size = 0;
+        let serialized_envelope = sys::envelope_serialize(envelope, &mut envelope_size);
+
+        if envelope_size == 0 || serialized_envelope.is_null() {
+            return Err(());
+        }
+
+        builder = builder.header("content-length", envelope_size);
+
+        Envelope {
+            inner: serialized_envelope,
+            len: envelope_size,
+        }
+    };
+
+    builder.body(envelope).map_err(|_| ())
+}
+
+fn from_dsn(
+    mut builder: http::request::Builder,
+    dsn_url: &str,
+) -> Result<http::request::Builder, ()> {
+    // A sentry DSN contains the following components:
+    // <https://<username>@<host>/<path>>
+    // * username = public key
+    // * host = obviously, the host, sentry.io in the case of the hosted service
+    // * path = the project ID
+    let url = url::Url::parse(dsn_url).map_err(|_| ())?;
+
+    // Do some basic checking that the DSN is remotely valid
+    if !url.scheme().starts_with("http")
+        || url.username().is_empty()
+        || !url.has_host()
+        || url.path().is_empty()
+        || url.path() == "/"
+    {
+        return Err(());
+    }
+
+    builder = builder.header(
+        "x-sentry-auth",
+        format!(
+            "Sentry sentry_key={}, sentry_version={}, sentry_client={}",
+            url.username(),
+            API_VERSION,
+            USER_AGENT
+        ),
+    );
+
+    builder = builder.uri(format!(
+        "{}://{}/api/{}/envelope/",
+        url.scheme(),
+        url.host_str().expect("DSN didn't contain a host"),
+        &url.path()[1..]
+    ));
+
+    Ok(builder)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parses_dsn() {
+        {
+            let hosted =
+                "https://a0b1c2d3e4f5678910abcdeffedcba12@o209016.ingest.sentry.io/0123456";
+
+            let mut builder = http::Request::builder();
+            builder = from_dsn(builder, hosted).expect("failed to parse hosted URL");
+
+            assert_eq!(
+                builder.uri_ref().unwrap(),
+                "https://o209016.ingest.sentry.io/api/0123456/envelope/"
+            );
+            let headers = builder.headers_ref().unwrap();
+            assert_eq!(headers.get("x-sentry-auth").unwrap(), &format!("Sentry sentry_key=a0b1c2d3e4f5678910abcdeffedcba12, sentry_version={}, sentry_client={}", API_VERSION, USER_AGENT));
+        }
+
+        {
+            let private = "http://a0b1c2d3e4f5678910abcdeffedcba12@192.168.1.1/0123456";
+
+            let mut builder = http::Request::builder();
+            builder = from_dsn(builder, private).expect("failed to parse private URL");
+
+            assert_eq!(
+                builder.uri_ref().unwrap(),
+                "http://192.168.1.1/api/0123456/envelope/"
+            );
+            let headers = builder.headers_ref().unwrap();
+            assert_eq!(headers.get("x-sentry-auth").unwrap(), &format!("Sentry sentry_key=a0b1c2d3e4f5678910abcdeffedcba12, sentry_version={}, sentry_client={}", API_VERSION, USER_AGENT));
+        }
+    }
+}


### PR DESCRIPTION
Adds a `custom-transport` feature which enables the new `transport` module and `Options::set_transport` to specify your own HTTP transport for data from the Native SDK to be sent to your Sentry service.

I added a minimal example on the `Options::set_transport` method to show how you can just use a closure as I didn't want to pull in an actual HTTP client crate, but I can flesh out the example to be more real if you want me too. I'm using `reqwest` in the project where I was testing that this custom transport feature works correctly, for example.

Resolves: #3