### PR TITLE
Add custom transports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,11 @@ jobs:
         run: cargo -v build ${{ matrix.feature }} ${{ matrix.rust.feature }}
       - name: Clippy
         if: always() && steps.checkout.outcome == 'success'
-        run:
+        run: |
           cargo clippy -v --all-targets ${{ matrix.feature }} ${{
           matrix.rust.feature }} -- -D warnings
       - name: Test
-        if:
+        if: |
           always() && steps.build.outcome == 'success' && matrix.feature ==
           '--features test'
         env:
@@ -107,7 +107,7 @@ jobs:
         if: always() && steps.checkout.outcome == 'success'
         env:
           RUSTDOCFLAGS: -D warnings
-        run:
+        run: |
           cargo -v doc --no-deps --document-private-items --workspace ${{
           matrix.feature }} ${{ matrix.rust.feature }}
       - name: Rust Formatting
@@ -219,11 +219,11 @@ jobs:
         run: cargo -v build ${{ matrix.feature }} ${{ matrix.rust.feature }}
       - name: Clippy
         if: always() && steps.checkout.outcome == 'success'
-        run:
+        run: |
           cargo clippy -v --all-targets ${{ matrix.feature }} ${{
           matrix.rust.feature }} -- -D warnings
       - name: Test
-        if:
+        if: |
           always() && steps.build.outcome == 'success' && matrix.feature ==
           '--features test'
         env:
@@ -233,7 +233,7 @@ jobs:
         if: always() && steps.checkout.outcome == 'success'
         env:
           RUSTDOCFLAGS: -D warnings
-        run:
+        run: |
           cargo -v doc --no-deps --document-private-items --workspace ${{
           matrix.feature }} ${{ matrix.rust.feature }}
       - name: Rust Formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Audit
-        run: cargo audit -D
+        run: |
+          cargo audit -D \
+          --ignore RUSTSEC-2020-0016 \ # Ignore net2 deprecation, only used by examples
+          --ignore RUSTSEC-2019-0031 # Ignore spin deprecation, only used by examples
 
   prettier:
     if: github.event_name != 'schedule'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
 # Used by the custom-transport example
 parking_lot = "0.10"
 reqwest = { version = "0.10", default-features = false, features = ["rustls-tls"] }
-tokio = { verion = "0.2", features = ["rt-threaded"] }
+tokio = { version = "0.2", features = ["rt-threaded"] }
 
 [features]
 default = ["default-transport"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ edition = "2018"
 members = ["sentry-contrib-native-sys"]
 
 [dependencies]
+http = { version = "0.2", optional = true }
 once_cell = "1"
 rmpv = "0.4"
 sys = { package = "sentry-contrib-native-sys", path = "sentry-contrib-native-sys", default-features = false }
 thiserror = "1"
+url = { version = "2.1", optional = true }
 vsprintf = "1"
 
 [dev-dependencies]
@@ -23,5 +25,6 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
 [features]
 default = ["default-transport"]
 default-transport = ["sys/default-transport"]
+custom-transport = ["http", "url"]
 nightly = []
 test = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,18 @@ rusty-fork = { git = "https://github.com/daxpedda/rusty-fork", branch = "proc-ma
   "macro"
 ] }
 
+# Used by the custom-transport example
+parking_lot = "0.10"
+reqwest = { version = "0.10", default-features = false, features = ["rustls-tls"] }
+tokio = { verion = "0.2", features = ["rt-threaded"] }
+
 [features]
 default = ["default-transport"]
 default-transport = ["sys/default-transport"]
 custom-transport = ["http", "url"]
 nightly = []
 test = []
+
+[[example]]
+name = "custom-transport"
+required-features = ["custom-transport"]

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ for more details.
 
 - **default-transport** - **Enabled by default**, will use `winhttp` on Windows
   and `curl` everywhere else as the default transport.
+- **custom-transport** - Allows you to register your own transport with the SDK
+to use instead of the default transports.
 - **test** - Corrects testing for documentation tests and examples.
 - **nightly** - Enables full documentation through
   [`feature(external_doc)`](https://doc.rust-lang.org/unstable-book/language-features/external-doc.html).

--- a/examples/custom-transport.rs
+++ b/examples/custom-transport.rs
@@ -1,0 +1,191 @@
+use sentry_contrib_native as sentry;
+use sentry::PostedEnvelope;
+use parking_lot::{Mutex, Condvar};
+use tokio::sync::mpsc;
+use std::sync::Arc;
+
+struct TransportState {
+    tx: mpsc::Sender<PostedEnvelope>,
+    shutdown: Arc<(Mutex<()>, Condvar)>,
+}
+
+async fn send_sentry_request(
+    client: &reqwest::Client,
+    req: sentry::SentryRequest,
+) -> Result<(), String> {
+    let (parts, body) = req.into_parts();
+    let uri = parts.uri.to_string();
+
+    // Sentry should only give us POST requests to send
+    if parts.method != http::Method::POST {
+        return Err(format!("Sentry SDK is trying to send an unexpected request of '{}'", parts.method));
+    }
+    
+    let rb = client.post(&parts.uri.to_string());
+
+    // We cheat so that we don't have to copy all of the bytes of the body
+    // into a new buffer, but we have to fake that the slice is static, which
+    // should be ok since we only need that buffer until the request is finished
+    #[allow(unsafe_code)]
+    let buffer = unsafe {
+        let buf = body.as_ref();
+        std::slice::from_raw_parts::<'static, u8>(buf.as_ptr(), buf.len())
+    };
+
+    let res = rb
+        .headers(parts.headers)
+        .body(reqwest::Body::from(buffer))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to send Sentry request: {}", e))?;
+
+    res.error_for_status()
+        .map_err(|e| format!("Received error response from Sentry: {}", e))?;
+    Ok(())
+}
+
+// We can implement our own transport for Sentry data so that we don't pull in
+// C dependencies (COUGH OPENSSL COUGH) that we don't want
+struct ReqwestTransport {
+    /// We don't currently use custom certs or proxies, so we can just use the
+    /// same client that the rest of ark uses, if we do start doing that, we
+    /// would need to build the client based on the options during startup()
+    client: reqwest::Client,
+    inner: Mutex<Option<TransportState>>,
+    rt: tokio::runtime::Handle,
+}
+
+impl ReqwestTransport {
+    fn new(client: reqwest::Client, rt: tokio::runtime::Handle) -> Self {
+        Self {
+            client,
+            inner: Mutex::new(None),
+            rt,
+        }
+    }
+}
+
+impl sentry::TransportWorker for ReqwestTransport {
+    fn startup(&self, dsn: sentry::Dsn, _debug: bool) {
+        let mut inner = self.inner.lock();
+        match *inner {
+            Some(_) => {
+                eprintln!("sentry transport has already been started!");
+            }
+            None => {
+                let (tx, mut rx) = mpsc::channel(1024);
+                let shutdown = Arc::new((Mutex::new(()), Condvar::new()));
+                let tshutdown = shutdown.clone();
+                let client = self.client.clone();
+
+                self.rt.enter(|| {
+                    tokio::spawn(async move {
+                        // Dequeue and send events until we are asked to shut down
+                        while let Some(envelope) = rx.recv().await {
+                            // Convert the envelope into an HTTP request
+                            match Self::convert_to_request(&dsn, envelope) {
+                                Ok(req) => match send_sentry_request(&client, req).await {
+                                    Ok(_) => eprintln!("successfully sent sentry envelope"),
+                                    Err(err) => {
+                                        eprintln!("failed to send sentry envelope: {}", err)
+                                    }
+                                },
+                                Err(err) => {
+                                    eprintln!("failed to convert Sentry request: {}", err);
+                                }
+                            }
+                        }
+
+                        // Shutting down, signal the condition variable that we've
+                        // finished sending everything, so that we can tell the
+                        // SDK about whether we've sent it all before their timeout
+                        let (lock, cvar) = &*tshutdown;
+                        let _shutdown = lock.lock();
+                        cvar.notify_one();
+                    });
+                });
+
+                *inner = Some(TransportState { tx, shutdown });
+            }
+        }
+    }
+
+    fn send(&self, envelope: PostedEnvelope) {
+        let inner = self.inner.lock();
+        if let Some(inner) = &*inner {
+            let mut tx = inner.tx.clone();
+            self.rt.enter(|| {
+                tokio::task::spawn(async move {
+                    if let Err(err) = tx.send(envelope).await {
+                        eprintln!("failed to send envelope to send queue: {}", err);
+                    }
+                });
+            });
+        }
+    }
+
+    fn shutdown(&self, timeout: std::time::Duration) -> sentry::TransportShutdown {
+        // Drop the sender so that the background thread will exit once
+        // it has dequeued and processed all the envelopes we have enqueued
+        let inner = self.inner.lock().take();
+
+        match inner {
+            Some(inner) => {
+                drop(inner.tx);
+
+                // Wait for the condition variable to notify that the thread has shutdown
+                let (lock, cvar) = &*inner.shutdown;
+                let mut shutdown = lock.lock();
+                let result = cvar.wait_for(&mut shutdown, timeout);
+
+                if result.timed_out() {
+                    sentry::TransportShutdown::TimedOut
+                } else {
+                    sentry::TransportShutdown::Success
+                }
+            }
+            None => sentry::TransportShutdown::Success,
+        }
+    }
+}
+
+fn main() -> Result<(), String> {
+    let mut options = sentry::Options::new();
+
+    // Setting a DSN is absolutely required to use custom transports
+    options.set_dsn("https://1234abcd@your.sentry.service.com/1234");
+
+    // This debug flag is supplied to our custom transport if we want to eg
+    // print debug information etc just as the underlying SDK does
+    options.set_debug(true);
+
+    // Setup a runtime, if you're using tokio or some other async runtime to
+    // send requests, you'll need to pass the handle to your transport so that
+    // you can actually spawn tasks correctly, since the calls are going to
+    // come on threads created by the C lib itself and won't have a runtime
+    // installed
+    let runtime = tokio::runtime::Builder::new()
+        .threaded_scheduler()
+        .enable_all()
+        .thread_name("sentry-tokio")
+        .build()
+        .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
+
+    // In this case we are creating a client just for the transport, but in
+    // a real app it is likely you would have this configured for other things
+    // and just reuse it for Sentry. If you are using proxies are custom certs
+    // with Sentry, you could also configure it here, or during startup, using
+    // the options you set
+    let client = reqwest::Client::new();
+
+    // Actually registers our custom transport so that the SDK will use that to
+    // send requests to your Sentry service, rather than the built in transports
+    // that come with the SDK
+    options.set_transport(sentry::Transport::new(Box::new(
+        ReqwestTransport::new(client, runtime.handle().clone()),
+    )));
+
+    let _shutdown = options.init().map_err(|e| format!("Failed to initialize Sentry: {}", e))?;
+
+    Ok(())
+}

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Build `sentry_native` with CMake.
+/// Build `sentry_native` with `CMake`.
 fn build(source: &Path) -> Result<PathBuf> {
     let mut cmake_config = Config::new(source);
     cmake_config

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -129,6 +129,7 @@ pub struct Transport([u8; 0]);
 /// sentry. It can contain one or more items, typically an Event.
 /// See <https://develop.sentry.dev/sdk/envelopes/>
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Envelope([u8; 0]);
 
 /// Type of the callback for modifying events.

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -326,7 +326,7 @@ extern "C" {
 
     /// Creates a new transport with an initial `send_func`.
     #[link_name = "sentry_transport_new"]
-    pub fn transport_new(send_fn: SendEnvelopeFunction) -> *mut Transport;
+    pub fn transport_new(send_func: Option<SendEnvelopeFunction>) -> *mut Transport;
 
     /// Sets the transport `state`.
     ///

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -344,7 +344,10 @@ extern "C" {
 
     /// Sets the transport startup hook.
     #[link_name = "sentry_transport_set_startup_func"]
-    pub fn transport_set_startup_func(transport: *mut Transport, startup_func: Option<StartupFunction>);
+    pub fn transport_set_startup_func(
+        transport: *mut Transport,
+        startup_func: Option<StartupFunction>,
+    );
 
     /// Sets the transport shutdown hook.
     ///
@@ -352,7 +355,10 @@ extern "C" {
     /// `true` in case all the pending envelopes have been sent within the timeout,
     /// or `false` if the timeout was hit.
     #[link_name = "sentry_transport_set_shutdown_func"]
-    pub fn transport_set_shutdown_func(transport: *mut Transport, shutdown_func: Option<ShutdownFunction>);
+    pub fn transport_set_shutdown_func(
+        transport: *mut Transport,
+        shutdown_func: Option<ShutdownFunction>,
+    );
 
     /// Generic way to free a transport.
     #[link_name = "sentry_transport_free"]

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -121,6 +121,7 @@ pub enum UserConsent {
 /// its internal queue without shutting down, and to dump its internal queue to
 /// disk in case of a hard crash.
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Transport([u8; 0]);
 
 /// A Sentry Envelope.

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -98,6 +98,28 @@ pub enum UserConsent {
 }
 
 /// This represents an interface for user-defined transports.
+///
+/// Transports are responsible for sending envelopes to sentry and are the last
+/// step in the event pipeline. A transport has the following hooks, all of which
+/// take the user provided `state` as last parameter. The transport state needs
+/// to be set with `sentry_transport_set_state` and typically holds handles and
+/// other information that can be reused across requests.
+///
+/// * `send_func`: This function will take ownership of an envelope, and is
+///   responsible for freeing it via `sentry_envelope_free`.
+/// * `startup_func`: This hook will be called by sentry and instructs the
+///   transport to initialize itself.
+/// * `shutdown_func`: Instructs the transport to flush its queue and shut down.
+///   This hook receives a millisecond-resolution `timeout` parameter and should
+///   return `true` when the transport was flushed and shut down successfully.
+///   In case of `false`, sentry will log an error, but continue with freeing the
+///   transport.
+/// * `free_func`: Frees the transports `state`. This hook might be called even
+///   though `shudown_func` returned `false` previously.
+///
+/// The transport interface might be extended in the future with hooks to flush
+/// its internal queue without shutting down, and to dump its internal queue to
+/// disk in case of a hard crash.
 #[repr(C)]
 pub struct Transport([u8; 0]);
 

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -344,7 +344,7 @@ extern "C" {
 
     /// Sets the transport startup hook.
     #[link_name = "sentry_transport_set_startup_func"]
-    pub fn transport_set_startup_hook(transport: *mut Transport, startup_fn: StartupFunction);
+    pub fn transport_set_startup_func(transport: *mut Transport, startup_func: Option<StartupFunction>);
 
     /// Sets the transport shutdown hook.
     ///

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -322,7 +322,7 @@ extern "C" {
     ///
     /// The return value needs to be freed with `sentry_string_free()`.
     #[link_name = "sentry_envelope_serialize"]
-    pub fn envelope_serialize(envelope: *const Envelope, size: &mut usize) -> *const c_char;
+    pub fn envelope_serialize(envelope: *const Envelope, size: *mut usize) -> *const c_char;
 
     /// Creates a new transport with an initial `send_func`.
     #[link_name = "sentry_transport_new"]

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -352,7 +352,7 @@ extern "C" {
     /// `true` in case all the pending envelopes have been sent within the timeout,
     /// or `false` if the timeout was hit.
     #[link_name = "sentry_transport_set_shutdown_func"]
-    pub fn transport_set_shutdown_func(transport: *mut Transport, shutdown_fn: ShutdownFunction);
+    pub fn transport_set_shutdown_func(transport: *mut Transport, shutdown_func: Option<ShutdownFunction>);
 
     /// Generic way to free a transport.
     #[link_name = "sentry_transport_free"]

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -339,7 +339,7 @@ extern "C" {
     #[link_name = "sentry_transport_set_free_func"]
     pub fn transport_set_free_func(
         transport: *mut Transport,
-        free_fn: extern "C" fn(state: *mut c_void),
+        free_func: Option<extern "C" fn(state: *mut c_void)>,
     );
 
     /// Sets the transport startup hook.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -31,6 +31,7 @@ impl CPath for PathBuf {
         #[cfg(windows)]
         let mut path: Vec<_> = self.into_os_string().encode_wide().collect();
         #[cfg(not(windows))]
+        #[allow(clippy::cast_possible_wrap)]
         let mut path: Vec<_> = self
             .into_os_string()
             .into_vec()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ mod value;
 pub use breadcrumb::Breadcrumb;
 pub use event::{Event, Interface, Uuid};
 use ffi::{CPath, CToR, RToC};
+#[cfg(feature = "custom-transport")]
+pub use http;
 use object::{Map, Object};
 use options::{global_read, global_write, BEFORE_SEND};
 pub use options::{BeforeSend, Options, Shutdown};
@@ -38,6 +40,8 @@ use std::{
     ptr,
 };
 use thiserror::Error;
+#[cfg(feature = "custom-transport")]
+pub use transport::{SentryRequest, Transport, Transporter};
 pub use user::User;
 pub use value::Value;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,9 @@ use std::{
 };
 use thiserror::Error;
 #[cfg(feature = "custom-transport")]
-pub use transport::{SentryRequest, Transport, Transporter};
+pub use transport::{
+    Dsn, PostedEnvelope, SentryRequest, Transport, TransportShutdown, TransportWorker,
+};
 pub use user::User;
 pub use value::Value;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ mod event;
 mod ffi;
 mod options;
 mod panic;
+#[cfg(feature = "custom-transport")]
+mod transport;
 mod user;
 mod value;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -138,6 +138,11 @@ impl Options {
         self.raw.expect("use after free")
     }
 
+    #[cfg(feature = "custom-transport")]
+    pub fn set_transport(&mut self, transport: Box<Transport>) {
+        unsafe {}
+    }
+
     /// Sets the before send callback.
     ///
     /// # Examples

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -165,7 +165,7 @@ impl Transport {
     /// can come at any time.
     #[must_use]
     pub fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Box<Self> {
-        let inner = unsafe { sys::transport_new(Self::send_function) };
+        let inner = unsafe { sys::transport_new(Some(Self::send_function)) };
 
         unsafe {
             let ret = Box::new(Self {
@@ -176,9 +176,9 @@ impl Transport {
 
             let ptr = ret.into_raw();
             sys::transport_set_state(inner, ptr);
-            sys::transport_set_startup_hook(inner, Self::startup);
-            sys::transport_set_shutdown_func(inner, Self::shutdown);
-            sys::transport_set_free_func(inner, Self::free);
+            sys::transport_set_startup_func(inner, Some(Self::startup));
+            sys::transport_set_shutdown_func(inner, Some(Self::shutdown));
+            sys::transport_set_free_func(inner, Some(Self::free));
 
             Self::from_raw(ptr)
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,145 +1,295 @@
+//! Contains types for creating custom transports that the underlying sentry-native
+//! library can use to send data to your upstream Sentry service in lieue of
+//! the built-in transports provided by the sentry-native library itself
+
 use std::{
     os::raw::c_void,
     sync::{mpsc, Arc, Condvar, Mutex},
 };
 
-/// Trait used to define your own transpor that Sentry can use to send events
+/// The request your [`Transporter`] is expected to send.
+pub type SentryRequest = http::Request<Envelope>;
+
+/// Trait used to define your own transport that Sentry can use to send events
 /// to a Sentry service
 pub trait Transporter {
-    fn send(&self, request: http::Request<Envelope>);
+    /// Method called when Sentry wishes to send data to a Sentry service
+    ///
+    /// The request contains all of the necessary pieces of data
+    /// * The uri to send the request to
+    /// * The headers that must be set
+    /// * The body of the request
+    ///
+    /// The `content-length` header is already set for you, though some HTTP
+    /// clients will automatically set it for you in some cases, which should
+    /// be fine.
+    ///
+    /// The `body` in the request is a [`Envelope`], which implements `AsRef<[u8]`
+    /// to retrieve the actual bytes that should be sent as the body
+    ///
+    /// # Errors
+    /// If your [`Transporter`] is unable to send the request, it can return
+    /// an error if it wishes. This error will be printed out to stderr if
+    /// you have enabled debugging in [`Options`]
+    fn send(&self, request: SentryRequest) -> Result<(), &'static str>;
 }
 
 impl<F> Transporter for F
 where
-    F: Fn(http::Request<Envelope>) + Send + Sync,
+    F: Fn(SentryRequest) -> Result<(), &'static str> + Send + Sync,
 {
-    fn send(&self, request: http::Request<Envelope>) {
+    fn send(&self, request: SentryRequest) -> Result<(), &'static str> {
         self(request)
     }
 }
 
+/// Wrapper around the raw pointer so that we can mark it as Send so that we
+/// postpone any actual work to the worker thread
+struct PostedEnvelope(*mut sys::Envelope);
+
+unsafe impl Send for PostedEnvelope {}
+
+/// Sentry internally uses a simple background thread worker to do the actual
+/// work of sending requests for the provided transports, so we do as well
 struct Worker {
-    tx: mpsc::Sender<*mut sys::Envelope>,
+    /// Sender we use to enqueue work to the background thread
+    tx: mpsc::Sender<PostedEnvelope>,
+    /// Condition variable we use to detect when the background thread has been
+    /// shutdown
+    shutdown: Arc<(Mutex<()>, Condvar)>,
+    /// True if the user specified they want debug information from the SDK
+    debug: bool,
 }
 
 impl Worker {
-    fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Self {
-        let (tx, rx) = mpsc::channel();
-        let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
+    /// Creates a new worker which spins up a thread to handle sending requests
+    /// to Sentry
+    fn new(debug: bool, dsn: Dsn, transporter: Box<dyn Transporter + Send + Sync>) -> Self {
+        let (tx, rx) = mpsc::channel::<PostedEnvelope>();
+        let shutdown = Arc::new((Mutex::new(()), Condvar::new()));
         let tshutdown = shutdown.clone();
 
-        let handle = std::thread::spawn(move || {
+        if debug {
+            eprintln!("[sentry-contrib-native]: Starting up worker thread");
+        }
+
+        std::thread::spawn(move || {
             while let Ok(envelope) = rx.recv() {
+                let envelope = envelope.0;
+
                 // We don't protect against panics here, but maybe that should
                 // be an option?
-                match construct_request(envelope) {
+                match construct_request(envelope, &dsn) {
                     Ok(request) => {
-                        transporter.send(request);
+                        if debug {
+                            eprintln!(
+                                "[sentry-contrib-native]: Sending envelope {} {:#?}",
+                                request.uri(),
+                                request.headers(),
+                            );
+                        }
+
+                        let res = transporter.send(request);
+
+                        if debug {
+                            match res {
+                                Ok(_) => {
+                                    eprintln!("[sentry-contrib-native]: Successfully sent envelope")
+                                }
+                                Err(err) => eprintln!(
+                                    "[sentry-contrib-native]: Failed to send envelope: {}",
+                                    err
+                                ),
+                            }
+                        }
                     }
                     Err(_) => unsafe { sys::envelope_free(envelope) },
                 }
             }
 
             let (lock, cvar) = &*tshutdown;
-            let mut shutdown = lock.lock().unwrap();
-            *shutdown = true;
+            let _shutdown = lock.lock().unwrap();
             cvar.notify_one();
         });
 
-        Self { tx, shutdown }
+        Self {
+            debug,
+            tx,
+            shutdown,
+        }
     }
 
+    /// Enqueues an envelope to be sent via the user's [`Transporter`]
     fn enqueue(&self, envelope: *mut sys::Envelope) {
-        self.tx.send(envelope).expect("failed to enqueue envelope");
+        self.tx
+            .send(PostedEnvelope(envelope))
+            .expect("failed to enqueue envelope");
     }
 
+    /// Shuts down the worker and waits for it be shutdown up to the specified
+    /// time. Returns `true` if the timeout is reached before the worker has
+    /// been fully shutdown.
     fn shutdown(self, timeout: std::time::Duration) -> bool {
+        if self.debug {
+            eprintln!("[sentry-contrib-native]: Shutting down worker thread");
+        }
+
+        // Drop the sender so that the background thread will exit once
+        // it has dequeued and processed all the envelopes we have enqueued
         drop(self.tx);
 
+        // Wait for the condition variable to notify that the thread has shutdown
         let (lock, cvar) = &*self.shutdown;
-        let mut shutdown = lock.lock().unwrap();
+        let shutdown = lock.lock().unwrap();
         let result = cvar.wait_timeout(shutdown, timeout).unwrap();
 
         result.1.timed_out()
     }
 }
 
+/// Holds the state for your custom transport. The lifetime of this state is
+/// handled by the underlying Sentry library, which is why you only get a `Box<>`
 pub struct Transport {
-    inner: *mut sys::Transport,
+    /// The inner transport that our state is attached to
+    pub(crate) inner: *mut sys::Transport,
+    /// The user's [`Transporter`] implementation, moved to the background
+    /// worker on startup
     user_impl: Option<Box<dyn Transporter + Send + Sync>>,
+    /// Our background worker
     worker: Option<Worker>,
 }
 
 impl Transport {
+    /// Creates a new Transport for Sentry using your provided [`Transporter`]
+    /// implementation. It's required to by [`Send`] and [`Sync`] as requests
+    /// can come at any time.
+    #[must_use]
     pub fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Box<Self> {
         let inner = unsafe { sys::transport_new(Self::send_function) };
 
-        let ret = Box::new(Self {
-            inner,
-            user_impl: transporter,
-            worker: None,
-        });
-
         unsafe {
-            sys::transport_set_state(inner, ret.as_ref().as_ptr() as *mut _);
-            sys::transport_set_startup_hook(inner, Self::startup);
-            sys::transport_set_shutdown_hook(inner, Self::shutdown);
-        }
+            let ret = Box::new(Self {
+                inner,
+                user_impl: Some(transporter),
+                worker: None,
+            });
 
-        ret
+            let ptr = ret.into_raw();
+            sys::transport_set_state(inner, ptr);
+            sys::transport_set_startup_hook(inner, Self::startup);
+            sys::transport_set_shutdown_func(inner, Self::shutdown);
+            sys::transport_set_free_func(inner, Self::free);
+
+            Self::from_raw(ptr)
+        }
     }
 
-    pub(crate) fn into_raw(self: Box<Self>) -> *mut c_void {
+    /// Convert ourselves into a state pointer, and prevents deallocating
+    #[inline]
+    fn into_raw(self: Box<Self>) -> *mut c_void {
         Box::into_raw(self) as *mut _
     }
 
-    pub(crate) fn from_raw(state: *mut c_void) -> Box<Self> {
+    /// Convert a state pointer back into a Box
+    #[inline]
+    fn from_raw(state: *mut c_void) -> Box<Self> {
         unsafe { Box::from_raw(state as *mut _) }
     }
 
-    fn send_function(envelope: *mut Envelope, state: *mut c_void) {
-        let self = Self::from_raw(state);
-        if let Some(q) = &self.queue {
+    /// The function registered with [`sys::transport_new`] when the SDK wishes
+    /// to send an envelope to Sentry
+    extern "C" fn send_function(envelope: *mut sys::Envelope, state: *mut c_void) {
+        let s = Self::from_raw(state);
+        if let Some(q) = &s.worker {
             q.enqueue(envelope);
         }
-        Self::into_raw(self);
+        s.into_raw();
     }
 
-    fn startup(options: *const sys::Options, state: *mut c_void) {
-        let self = Self::from_raw(state);
+    /// The function registered with [`sys::transport_set_startup_hook`] to
+    /// start our transport so that we can being sending requests to Sentry
+    extern "C" fn startup(options: *const sys::Options, state: *mut c_void) {
+        let mut s = Self::from_raw(state);
 
-        match self.user_impl.take() {
-            Some(imp) => self.worker = Some(Worker::new(imp)),
-            None => {}
+        if let Some(imp) = s.user_impl.take() {
+            unsafe {
+                let dsn = sys::options_get_dsn(options);
+                let debug = sys::options_get_debug(options) == 1;
+
+                if dsn.is_null() {
+                    if debug {
+                        eprintln!("[sentry-contrib-native]: DSN is null");
+                    }
+
+                    s.into_raw();
+                    return;
+                }
+
+                let dsn = std::ffi::CStr::from_ptr(dsn);
+
+                match dsn.to_str() {
+                    Ok(dsn_url) => match dsn_url.parse() {
+                        Ok(dsn) => {
+                            s.worker = Some(Worker::new(debug, dsn, imp));
+                        }
+                        Err(err) => {
+                            if debug {
+                                eprintln!("[sentry-contrib-native]: Failed to parse DSN: {}", err);
+                            }
+                        }
+                    },
+                    Err(err) => {
+                        if debug {
+                            eprintln!(
+                                "[sentry-contrib-native]: DSN url has invalid UTF-8: {}",
+                                err
+                            );
+                        }
+                    }
+                }
+            }
         }
 
-        self.into_raw()
+        s.into_raw();
     }
 
-    fn shutdown(timeout: u64, state: *mut c_void) -> bool {
-        let self = Self::from_raw(state);
+    /// The function registered with [`sys::transport_set_shutdown_func`] which
+    /// will attempt to flush all of the outstanding requests via the transport,
+    /// and shutdown the worker thread, before the specified timeout is reached
+    extern "C" fn shutdown(timeout: u64, state: *mut c_void) -> bool {
+        let mut s = Self::from_raw(state);
 
-        let sent_all = match self.worker.take() {
-            Some(worker) => !worker.shutdown(),
+        let sent_all = match s.worker.take() {
+            Some(worker) => !worker.shutdown(std::time::Duration::from_millis(timeout)),
             None => true,
         };
 
-        self.into_raw();
+        s.into_raw();
 
         sent_all
+    }
+
+    /// The function registered with [`sys::transport_set_free_func`] that
+    /// actually frees
+    extern "C" fn free(state: *mut c_void) {
+        let mut s = Self::from_raw(state);
+        s.inner = std::ptr::null_mut();
     }
 }
 
 impl Drop for Transport {
     fn drop(&mut self) {
         unsafe {
-            sys::transport_free(self.inner);
+            if !self.inner.is_null() {
+                sys::transport_free(self.inner);
+            }
         }
     }
 }
 
 /// From sentry.h, but only present as a preprocessor define :(
 const USER_AGENT: &str = "sentry.native/0.3.2";
+/// The MIME type for Sentry envelopes
 const ENVELOPE_MIME: &str = "application/x-sentry-envelope";
 /// Version of the Sentry API we can communicate with, AFAICT this is just
 /// hardcoded into sentry-native, so...two can play at that game!
@@ -147,10 +297,16 @@ const API_VERSION: i8 = 7;
 
 /// The actual body which transports send to Sentry.
 pub struct Envelope {
+    /// The underlying opaque pointer. Freed once we are finished with the envelope.
     inner: *mut sys::Envelope,
+    /// The raw bytes of the serialized envelope, which is the actual data to
+    /// send as the body of a request
     data: *const std::os::raw::c_char,
+    /// The length in bytes of the serialized data
     len: usize,
 }
+
+unsafe impl Send for Envelope {}
 
 impl AsRef<[u8]> for Envelope {
     fn as_ref(&self) -> &[u8] {
@@ -167,9 +323,77 @@ impl Drop for Envelope {
     }
 }
 
-fn construct_request(envelope: *mut sys::Envelope) -> Result<http::Request<Envelope>, ()> {
-    use std::ffi::CStr;
+/// Contains the pieces we need to send requests based on the DSN the user
+/// set on [`Options`]
+struct Dsn {
+    /// The auth header value
+    auth: String,
+    /// The full URI to send envelopes to
+    uri: String,
+}
 
+impl Dsn {
+    /// Adds the URI and auth header to the request
+    #[inline]
+    fn build_req(&self, mut rb: http::request::Builder) -> http::request::Builder {
+        rb = rb.header("x-sentry-auth", &self.auth);
+        rb.uri(&self.uri)
+    }
+}
+
+impl std::str::FromStr for Dsn {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // A sentry DSN contains the following components:
+        // <https://<username>@<host>/<path>>
+        // * username = public key
+        // * host = obviously, the host, sentry.io in the case of the hosted service
+        // * path = the project ID
+        let url = url::Url::parse(s).map_err(|_| "failed to parse DSN url")?;
+
+        // Do some basic checking that the DSN is remotely valid
+        if !url.scheme().starts_with("http") {
+            return Err("DSN doesn't have an http(s) scheme");
+        }
+
+        if url.username().is_empty() {
+            return Err("DSN has no username");
+        }
+
+        if url.path().is_empty() || url.path() == "/" {
+            return Err("DSN doesn't have a path");
+        }
+
+        match url.host_str() {
+            Some(host) => {
+                let auth = format!(
+                    "Sentry sentry_key={}, sentry_version={}, sentry_client={}",
+                    url.username(),
+                    API_VERSION,
+                    USER_AGENT
+                );
+
+                let uri = format!(
+                    "{}://{}/api/{}/envelope/",
+                    url.scheme(),
+                    host,
+                    &url.path()[1..]
+                );
+
+                Ok(Self { auth, uri })
+            }
+            None => Err("DSN doesn't have a host"),
+        }
+    }
+}
+
+/// Constructs an HTTP request for the provided [`sys::Envelope`] with the DSN
+/// that was registered with the SDK
+fn construct_request(
+    envelope: *mut sys::Envelope,
+    dsn: &Dsn,
+) -> Result<http::Request<Envelope>, ()> {
     let mut builder = http::Request::builder();
 
     {
@@ -180,26 +404,10 @@ fn construct_request(envelope: *mut sys::Envelope) -> Result<http::Request<Envel
     }
 
     builder = builder.method("POST");
+    builder = dsn.build_req(builder);
 
     // Get the DSN for the options, which informs us where to send the request, and what auth token to use
     let envelope = unsafe {
-        let opts = sys::get_options();
-
-        if opts.is_null() {
-            return Err(());
-        }
-
-        let dsn = sys::options_get_dsn(opts);
-
-        if dsn.is_null() {
-            return Err(());
-        }
-
-        let dsn = CStr::from_ptr(dsn);
-        let dsn_url = dsn.to_str().map_err(|_| ())?;
-
-        builder = from_dsn(builder, dsn_url)?;
-
         let mut envelope_size = 0;
         let serialized_envelope = sys::envelope_serialize(envelope, &mut envelope_size);
 
@@ -210,53 +418,13 @@ fn construct_request(envelope: *mut sys::Envelope) -> Result<http::Request<Envel
         builder = builder.header("content-length", envelope_size);
 
         Envelope {
-            inner: serialized_envelope,
+            inner: envelope,
+            data: serialized_envelope,
             len: envelope_size,
         }
     };
 
     builder.body(envelope).map_err(|_| ())
-}
-
-fn from_dsn(
-    mut builder: http::request::Builder,
-    dsn_url: &str,
-) -> Result<http::request::Builder, ()> {
-    // A sentry DSN contains the following components:
-    // <https://<username>@<host>/<path>>
-    // * username = public key
-    // * host = obviously, the host, sentry.io in the case of the hosted service
-    // * path = the project ID
-    let url = url::Url::parse(dsn_url).map_err(|_| ())?;
-
-    // Do some basic checking that the DSN is remotely valid
-    if !url.scheme().starts_with("http")
-        || url.username().is_empty()
-        || !url.has_host()
-        || url.path().is_empty()
-        || url.path() == "/"
-    {
-        return Err(());
-    }
-
-    builder = builder.header(
-        "x-sentry-auth",
-        format!(
-            "Sentry sentry_key={}, sentry_version={}, sentry_client={}",
-            url.username(),
-            API_VERSION,
-            USER_AGENT
-        ),
-    );
-
-    builder = builder.uri(format!(
-        "{}://{}/api/{}/envelope/",
-        url.scheme(),
-        url.host_str().expect("DSN didn't contain a host"),
-        &url.path()[1..]
-    ));
-
-    Ok(builder)
 }
 
 #[cfg(test)]
@@ -270,7 +438,8 @@ mod test {
                 "https://a0b1c2d3e4f5678910abcdeffedcba12@o209016.ingest.sentry.io/0123456";
 
             let mut builder = http::Request::builder();
-            builder = from_dsn(builder, hosted).expect("failed to parse hosted URL");
+            let dsn: Dsn = hosted.parse().expect("failed to parse hosted DSN");
+            builder = dsn.build_req(builder);
 
             assert_eq!(
                 builder.uri_ref().unwrap(),
@@ -284,7 +453,8 @@ mod test {
             let private = "http://a0b1c2d3e4f5678910abcdeffedcba12@192.168.1.1/0123456";
 
             let mut builder = http::Request::builder();
-            builder = from_dsn(builder, private).expect("failed to parse private URL");
+            let dsn: Dsn = private.parse().expect("failed to parse hosted DSN");
+            builder = dsn.build_req(builder);
 
             assert_eq!(
                 builder.uri_ref().unwrap(),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,297 @@
+use std::{
+    os::raw::c_void,
+    sync::{mpsc, Arc, Condvar, Mutex},
+};
+
+/// Trait used to define your own transpor that Sentry can use to send events
+/// to a Sentry service
+pub trait Transporter {
+    fn send(&self, request: http::Request<Envelope>);
+}
+
+impl<F> Transporter for F
+where
+    F: Fn(http::Request<Envelope>) + Send + Sync,
+{
+    fn send(&self, request: http::Request<Envelope>) {
+        self(request)
+    }
+}
+
+struct Worker {
+    tx: mpsc::Sender<*mut sys::Envelope>,
+}
+
+impl Worker {
+    fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
+        let tshutdown = shutdown.clone();
+
+        let handle = std::thread::spawn(move || {
+            while let Ok(envelope) = rx.recv() {
+                // We don't protect against panics here, but maybe that should
+                // be an option?
+                match construct_request(envelope) {
+                    Ok(request) => {
+                        transporter.send(request);
+                    }
+                    Err(_) => unsafe { sys::envelope_free(envelope) },
+                }
+            }
+
+            let (lock, cvar) = &*tshutdown;
+            let mut shutdown = lock.lock().unwrap();
+            *shutdown = true;
+            cvar.notify_one();
+        });
+
+        Self { tx, shutdown }
+    }
+
+    fn enqueue(&self, envelope: *mut sys::Envelope) {
+        self.tx.send(envelope).expect("failed to enqueue envelope");
+    }
+
+    fn shutdown(self, timeout: std::time::Duration) -> bool {
+        drop(self.tx);
+
+        let (lock, cvar) = &*self.shutdown;
+        let mut shutdown = lock.lock().unwrap();
+        let result = cvar.wait_timeout(shutdown, timeout).unwrap();
+
+        result.1.timed_out()
+    }
+}
+
+pub struct Transport {
+    inner: *mut sys::Transport,
+    user_impl: Option<Box<dyn Transporter + Send + Sync>>,
+    worker: Option<Worker>,
+}
+
+impl Transport {
+    pub fn new(transporter: Box<dyn Transporter + Send + Sync>) -> Box<Self> {
+        let inner = unsafe { sys::transport_new(Self::send_function) };
+
+        let ret = Box::new(Self {
+            inner,
+            user_impl: transporter,
+            worker: None,
+        });
+
+        unsafe {
+            sys::transport_set_state(inner, ret.as_ref().as_ptr() as *mut _);
+            sys::transport_set_startup_hook(inner, Self::startup);
+            sys::transport_set_shutdown_hook(inner, Self::shutdown);
+        }
+
+        ret
+    }
+
+    pub(crate) fn into_raw(self: Box<Self>) -> *mut c_void {
+        Box::into_raw(self) as *mut _
+    }
+
+    pub(crate) fn from_raw(state: *mut c_void) -> Box<Self> {
+        unsafe { Box::from_raw(state as *mut _) }
+    }
+
+    fn send_function(envelope: *mut Envelope, state: *mut c_void) {
+        let self = Self::from_raw(state);
+        if let Some(q) = &self.queue {
+            q.enqueue(envelope);
+        }
+        Self::into_raw(self);
+    }
+
+    fn startup(options: *const sys::Options, state: *mut c_void) {
+        let self = Self::from_raw(state);
+
+        match self.user_impl.take() {
+            Some(imp) => self.worker = Some(Worker::new(imp)),
+            None => {}
+        }
+
+        self.into_raw()
+    }
+
+    fn shutdown(timeout: u64, state: *mut c_void) -> bool {
+        let self = Self::from_raw(state);
+
+        let sent_all = match self.worker.take() {
+            Some(worker) => !worker.shutdown(),
+            None => true,
+        };
+
+        self.into_raw();
+
+        sent_all
+    }
+}
+
+impl Drop for Transport {
+    fn drop(&mut self) {
+        unsafe {
+            sys::transport_free(self.inner);
+        }
+    }
+}
+
+/// From sentry.h, but only present as a preprocessor define :(
+const USER_AGENT: &str = "sentry.native/0.3.2";
+const ENVELOPE_MIME: &str = "application/x-sentry-envelope";
+/// Version of the Sentry API we can communicate with, AFAICT this is just
+/// hardcoded into sentry-native, so...two can play at that game!
+const API_VERSION: i8 = 7;
+
+/// The actual body which transports send to Sentry.
+pub struct Envelope {
+    inner: *mut sys::Envelope,
+    data: *const std::os::raw::c_char,
+    len: usize,
+}
+
+impl AsRef<[u8]> for Envelope {
+    fn as_ref(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.data as *const _, self.len) }
+    }
+}
+
+impl Drop for Envelope {
+    fn drop(&mut self) {
+        unsafe {
+            sys::free(self.data as *mut _);
+            sys::envelope_free(self.inner);
+        }
+    }
+}
+
+fn construct_request(envelope: *mut sys::Envelope) -> Result<http::Request<Envelope>, ()> {
+    use std::ffi::CStr;
+
+    let mut builder = http::Request::builder();
+
+    {
+        let headers = builder.headers_mut().expect("unable to mutate headers");
+        headers.insert("user-agent", USER_AGENT.parse().unwrap());
+        headers.insert("content-type", ENVELOPE_MIME.parse().unwrap());
+        headers.insert("accept", "*/*".parse().unwrap());
+    }
+
+    builder = builder.method("POST");
+
+    // Get the DSN for the options, which informs us where to send the request, and what auth token to use
+    let envelope = unsafe {
+        let opts = sys::get_options();
+
+        if opts.is_null() {
+            return Err(());
+        }
+
+        let dsn = sys::options_get_dsn(opts);
+
+        if dsn.is_null() {
+            return Err(());
+        }
+
+        let dsn = CStr::from_ptr(dsn);
+        let dsn_url = dsn.to_str().map_err(|_| ())?;
+
+        builder = from_dsn(builder, dsn_url)?;
+
+        let mut envelope_size = 0;
+        let serialized_envelope = sys::envelope_serialize(envelope, &mut envelope_size);
+
+        if envelope_size == 0 || serialized_envelope.is_null() {
+            return Err(());
+        }
+
+        builder = builder.header("content-length", envelope_size);
+
+        Envelope {
+            inner: serialized_envelope,
+            len: envelope_size,
+        }
+    };
+
+    builder.body(envelope).map_err(|_| ())
+}
+
+fn from_dsn(
+    mut builder: http::request::Builder,
+    dsn_url: &str,
+) -> Result<http::request::Builder, ()> {
+    // A sentry DSN contains the following components:
+    // <https://<username>@<host>/<path>>
+    // * username = public key
+    // * host = obviously, the host, sentry.io in the case of the hosted service
+    // * path = the project ID
+    let url = url::Url::parse(dsn_url).map_err(|_| ())?;
+
+    // Do some basic checking that the DSN is remotely valid
+    if !url.scheme().starts_with("http")
+        || url.username().is_empty()
+        || !url.has_host()
+        || url.path().is_empty()
+        || url.path() == "/"
+    {
+        return Err(());
+    }
+
+    builder = builder.header(
+        "x-sentry-auth",
+        format!(
+            "Sentry sentry_key={}, sentry_version={}, sentry_client={}",
+            url.username(),
+            API_VERSION,
+            USER_AGENT
+        ),
+    );
+
+    builder = builder.uri(format!(
+        "{}://{}/api/{}/envelope/",
+        url.scheme(),
+        url.host_str().expect("DSN didn't contain a host"),
+        &url.path()[1..]
+    ));
+
+    Ok(builder)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parses_dsn() {
+        {
+            let hosted =
+                "https://a0b1c2d3e4f5678910abcdeffedcba12@o209016.ingest.sentry.io/0123456";
+
+            let mut builder = http::Request::builder();
+            builder = from_dsn(builder, hosted).expect("failed to parse hosted URL");
+
+            assert_eq!(
+                builder.uri_ref().unwrap(),
+                "https://o209016.ingest.sentry.io/api/0123456/envelope/"
+            );
+            let headers = builder.headers_ref().unwrap();
+            assert_eq!(headers.get("x-sentry-auth").unwrap(), &format!("Sentry sentry_key=a0b1c2d3e4f5678910abcdeffedcba12, sentry_version={}, sentry_client={}", API_VERSION, USER_AGENT));
+        }
+
+        {
+            let private = "http://a0b1c2d3e4f5678910abcdeffedcba12@192.168.1.1/0123456";
+
+            let mut builder = http::Request::builder();
+            builder = from_dsn(builder, private).expect("failed to parse private URL");
+
+            assert_eq!(
+                builder.uri_ref().unwrap(),
+                "http://192.168.1.1/api/0123456/envelope/"
+            );
+            let headers = builder.headers_ref().unwrap();
+            assert_eq!(headers.get("x-sentry-auth").unwrap(), &format!("Sentry sentry_key=a0b1c2d3e4f5678910abcdeffedcba12, sentry_version={}, sentry_client={}", API_VERSION, USER_AGENT));
+        }
+    }
+}


### PR DESCRIPTION
Adds a `custom-transport` feature which enables the new `transport` module and `Options::set_transport` to specify your own HTTP transport for data from the Native SDK to be sent to your Sentry service.

I added a minimal example on the `Options::set_transport` method to show how you can just use a closure as I didn't want to pull in an actual HTTP client crate, but I can flesh out the example to be more real if you want me too. I'm using `reqwest` in the project where I was testing that this custom transport feature works correctly, for example.

Resolves: #3