### PR TITLE
Add backend selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
             }
         feature:
           - {
-              name: "--no-default-features --features custom-transport",
+              name:
+                "--no-default-features --features
+                backend-default,custom-transport",
               default-transport: false,
               custom-transport: true,
             }
@@ -245,7 +247,9 @@ jobs:
             }
         feature:
           - {
-              name: "--no-default-features --features custom-transport",
+              name:
+                "--no-default-features --features
+                backend-default,custom-transport",
               default-transport: false,
               custom-transport: true,
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Added support for changing the backend.
+
 ### Changed
 
 - Replaced `user_consent_give`, `user_consent_revoke` and `user_consent_reset`
@@ -24,6 +26,8 @@ and this project adheres to
 
 - Fixed thread-safety in almost all functions, they could crash the application
   otherwise or cause undefined behaviour.
+- Fixed unnecessary include of the WinHttp library when the default transport is
+  disabled.
 
 ### Security
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,14 +48,13 @@ tokio = { version = "0.2", features = ["macros", "process", "rt-threaded"] }
 url = "2"
 
 [features]
-default = ["default-transport"]
+default = ["backend-default", "default-transport"]
 default-transport = ["sys/default-transport"]
 custom-transport = ["http", "url"]
-backend-none = ["sys/backend-none"]
+backend-default = ["sys/backend-default"]
 backend-crashpad = ["sys/backend-crashpad"]
 backend-breakpad = ["sys/backend-breakpad"]
 backend-inproc = ["sys/backend-inproc"]
-
 nightly = ["sys/nightly"]
 test = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,11 @@ url = "2"
 default = ["default-transport"]
 default-transport = ["sys/default-transport"]
 custom-transport = ["http", "url"]
+backend-none = ["sys/backend-none"]
+backend-crashpad = ["sys/backend-crashpad"]
+backend-breakpad = ["sys/backend-breakpad"]
+backend-inproc = ["sys/backend-inproc"]
+
 nightly = ["sys/nightly"]
 test = []
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ fn main() {
 }
 ```
 
-On MacOS and Windows the Crashpad handler executable has to be shipped with the
-application, for convenience the Crashpad handler executable will be copied to
-Cargo's default binary output folder, so using `cargo run` works without any
-additional setup or configuration.
+By default, on MacOS and Windows the Crashpad handler executable has to be
+shipped with the application, for convenience the Crashpad handler executable
+will be copied to Cargo's default binary output folder, so using `cargo run`
+works without any additional setup or configuration.
 
 If you need to export the Crashpad handler executable programmatically to a
 specific output path, a "convenient" environment variable is provided to help
@@ -131,6 +131,8 @@ for more detailed information. See the
 platform and feature support details there, this crate doesn't do anything
 fancy, so we mostly rely on `sentry-native` for support.
 
+Only the default backend is tested in the CI.
+
 ## Build
 
 This crate relies on
@@ -148,8 +150,17 @@ details.
 
 ## Crate features
 
+- **backend-default** - **Enabled by default**, will use Crashpad on MacOS and
+  Windows, Breakpad on Linux and InProc for Android. See `SENTRY_BACKEND` at the
+  [Sentry Native SDK](https://github.com/getsentry/sentry-native).
 - **default-transport** - **Enabled by default**, will use `winhttp` on Windows
   and `curl` everywhere else as the default transport.
+- **backend-crashpad** - Will use Crashpad. See `SENTRY_BACKEND` at the
+  [Sentry Native SDK](https://github.com/getsentry/sentry-native).
+- **backend-breakpad** - Will use Breakpad. See `SENTRY_BACKEND` at the
+  [Sentry Native SDK](https://github.com/getsentry/sentry-native).
+- **backend-inproc** - Will use InProc. See `SENTRY_BACKEND` at the
+  [Sentry Native SDK](https://github.com/getsentry/sentry-native).
 - **custom-transport** - Adds helper types and methods to custom transport.
 - **test** - Corrects testing for documentation tests and examples.
   - Automatically sets the DSN to the `SENTRY_DSN` environment variable, no
@@ -166,9 +177,10 @@ details.
 
 ## Deployment
 
-When deploying a binary for MacOS or Windows, it has to be shipped together with
-the `crashpad_handler(.exe)` executable. A way to programmatically export it
-using `build.rs` is provided through the `DEP_SENTRY_NATIVE_CRASHPAD_HANDLER`.
+By default, when deploying a binary for MacOS or Windows, it has to be shipped
+together with the `crashpad_handler(.exe)` executable. A way to programmatically
+export it using `build.rs` is provided through the
+`DEP_SENTRY_NATIVE_CRASHPAD_HANDLER`.
 
 See the [Usage section](#usage) for an example.
 

--- a/sentry-contrib-native-sys/Cargo.toml
+++ b/sentry-contrib-native-sys/Cargo.toml
@@ -19,6 +19,10 @@ cmake = "0.1"
 default = ["default-transport"]
 default-transport = []
 nightly = []
+backend-none = []
+backend-crashpad = []
+backend-breakpad = []
+backend-inproc = []
 
 [package.metadata.docs.rs]
 features = ["nightly"]

--- a/sentry-contrib-native-sys/Cargo.toml
+++ b/sentry-contrib-native-sys/Cargo.toml
@@ -16,10 +16,10 @@ anyhow = "1"
 cmake = "0.1"
 
 [features]
-default = ["default-transport"]
+default = ["backend-default", "default-transport"]
 default-transport = []
 nightly = []
-backend-none = []
+backend-default = []
 backend-crashpad = []
 backend-breakpad = []
 backend-inproc = []

--- a/sentry-contrib-native-sys/README.md
+++ b/sentry-contrib-native-sys/README.md
@@ -30,8 +30,17 @@ For more details see
 
 ## Crate features
 
+- **backend-default** - **Enabled by default**, will use Crashpad on MacOS and
+  Windows, Breakpad on Linux and InProc for Android. See `SENTRY_BACKEND` at the
+  [Sentry Native SDK](https://github.com/getsentry/sentry-native).
 - **default-transport** - **Enabled by default**, will use `winhttp` on Windows
   and `curl` everywhere else as the default transport.
+- **backend-crashpad** - Will use Crashpad. See `SENTRY_BACKEND` at the
+  [Sentry Native SDK](https://github.com/getsentry/sentry-native).
+- **backend-breakpad** - Will use Breakpad. See `SENTRY_BACKEND` at the
+  [Sentry Native SDK](https://github.com/getsentry/sentry-native).
+- **backend-inproc** - Will use InProc. See `SENTRY_BACKEND` at the
+  [Sentry Native SDK](https://github.com/getsentry/sentry-native).
 - **nightly** - Enables full documentation through
   [`feature(external_doc)`](https://doc.rust-lang.org/unstable-book/language-features/external-doc.html).
 

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -21,9 +21,54 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[derive(Copy, Clone)]
+enum Backend {
+    Inproc,
+    Crashpad,
+    Breakpad,
+    None,
+}
+
+fn get_target_default(target_os: &str) -> Backend {
+    match target_os {
+        "windows" | "macos" => Backend::Crashpad,
+        "linux" => Backend::Breakpad,
+        "android" => Backend::Inproc,
+        _ => Backend::None,
+    }
+}
+
+/// Gets the backend we want to use, see https://github.com/getsentry/sentry-native#compile-time-options
+/// for details
+fn get_backend(target_os: &str) -> Backend {
+    if cfg!(feature = "backend-none") {
+        return Backend::None;
+    }
+
+    if cfg!(feature = "backend-crashpad")
+        && (target_os == "macos" || target_os == "windows" || target_os == "linux")
+    {
+        return Backend::Crashpad;
+    }
+
+    if cfg!(feature = "backend-breakpad") && (target_os == "windows" || target_os == "linux") {
+        return Backend::Breakpad;
+    }
+
+    if cfg!(feature = "backend-inproc") {
+        return Backend::Inproc;
+    }
+
+    get_target_default(target_os)
+}
+
 fn main() -> Result<()> {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target OS not specified");
+
     // path to source.
     let source = PathBuf::from("sentry-native");
+    let backend = get_backend(&target_os);
+
     // path to installation or to install to
     let install = if let Some(install) = env::var_os("SENTRY_NATIVE_INSTALL").map(PathBuf::from) {
         if fs::read_dir(&install)
@@ -31,12 +76,12 @@ fn main() -> Result<()> {
             .and_then(|mut dir| dir.next())
             .is_none()
         {
-            build(&source, Some(&install))?
+            build(&source, Some(&install), backend)?
         } else {
             install
         }
     } else {
-        build(&source, None)?
+        build(&source, None, backend)?
     };
 
     println!("cargo:rerun-if-env-changed=SENTRY_NATIVE_INSTALL");
@@ -62,26 +107,15 @@ fn main() -> Result<()> {
     );
     println!("cargo:rustc-link-lib=sentry");
 
-    match env::var("CARGO_CFG_TARGET_OS")
-        .expect("target OS not specified")
-        .as_str()
-    {
-        crashpad if crashpad == "windows" || crashpad == "macos" => {
+    match backend {
+        Backend::Crashpad => {
             println!("cargo:rustc-link-lib=crashpad_client");
             println!("cargo:rustc-link-lib=crashpad_util");
             println!("cargo:rustc-link-lib=mini_chromium");
 
-            let handler = if crashpad == "windows" {
-                println!("cargo:rustc-link-lib=dbghelp");
-                println!("cargo:rustc-link-lib=shlwapi");
-                println!("cargo:rustc-link-lib=winhttp");
-
+            let handler = if target_os == "windows" {
                 "crashpad_handler.exe"
             } else {
-                println!("cargo:rustc-link-lib=framework=Foundation");
-                println!("cargo:rustc-link-lib=curl");
-                println!("cargo:rustc-link-lib=dylib=c++");
-
                 "crashpad_handler"
             };
 
@@ -90,15 +124,37 @@ fn main() -> Result<()> {
                 install.join("bin").join(handler).display()
             );
         }
-        "linux" => {
+        Backend::Breakpad => {
             println!("cargo:rustc-link-lib=breakpad_client");
+        }
+        _ => {}
+    }
 
+    match target_os.as_str() {
+        "windows" => {
+            println!("cargo:rustc-link-lib=dbghelp");
+            println!("cargo:rustc-link-lib=shlwapi");
+
+            if cfg!(feature = "default-transport") {
+                println!("cargo:rustc-link-lib=winhttp");
+            }
+        }
+        "macos" => {
+            println!("cargo:rustc-link-lib=framework=Foundation");
+            println!("cargo:rustc-link-lib=dylib=c++");
+
+            if cfg!(feature = "default-transport") {
+                println!("cargo:rustc-link-lib=curl");
+            }
+        }
+        "linux" => {
             if cfg!(feature = "default-transport") {
                 println!("cargo:rustc-link-lib=curl");
             }
 
             println!("cargo:rustc-link-lib=dylib=stdc++");
         }
+        "android" => {}
         other => unimplemented!("target platform {} not implemented", other),
     }
 
@@ -106,7 +162,7 @@ fn main() -> Result<()> {
 }
 
 /// Build `sentry_native` with `CMake`.
-fn build(source: &Path, install: Option<&Path>) -> Result<PathBuf> {
+fn build(source: &Path, install: Option<&Path>, backend: Backend) -> Result<PathBuf> {
     let mut cmake_config = Config::new(source);
     cmake_config
         .define("BUILD_SHARED_LIBS", "OFF")
@@ -122,6 +178,15 @@ fn build(source: &Path, install: Option<&Path>) -> Result<PathBuf> {
     if cfg!(not(feature = "default-transport")) {
         cmake_config.define("SENTRY_TRANSPORT", "none");
     }
+
+    let be = match backend {
+        Backend::Crashpad => "crashpad",
+        Backend::Breakpad => "breakpad",
+        Backend::Inproc => "inproc",
+        Backend::None => "none",
+    };
+
+    cmake_config.define("SENTRY_BACKEND", be);
 
     if cfg!(target_feature = "crt-static") {
         cmake_config.define("SENTRY_BUILD_RUNTIMESTATIC", "ON");


### PR DESCRIPTION
Initial pass at adding backend selection via features. There's probably a better way to do this but this at least gets the ball rolling. Not specifying a backend feature gives the default for the target OS, and it's currently prioritized as None -> Crashpad -> Breakpad -> Inproc.