### PR TITLE
Exclude some breakpad test data from packaging

### DIFF
--- a/sentry-contrib-native-sys/Cargo.toml
+++ b/sentry-contrib-native-sys/Cargo.toml
@@ -11,6 +11,13 @@ license = "MIT OR Apache-2.0"
 keywords = ["sentry", "crash", "crashpad", "breakpad", "minidump"]
 categories = ["external-ffi-bindings", "development-tools::debugging"]
 
+exclude = [
+    # Exclude test data for breakpad, as it's unnecessary and can break during
+    # unpacking on windows depending on the how long the user's .cargo path is
+    "sentry-native/external/breakpad/src/processor/testdata/**",
+    "sentry-native/external/breakpad/src/tools/windows/dump_syms/testdata/**",
+]
+
 [build-dependencies]
 anyhow = "1"
 cmake = "0.1"

--- a/sentry-contrib-native-sys/Cargo.toml
+++ b/sentry-contrib-native-sys/Cargo.toml
@@ -10,12 +10,14 @@ repository = "https://github.com/daxpedda/sentry-contrib-native"
 license = "MIT OR Apache-2.0"
 keywords = ["sentry", "crash", "crashpad", "breakpad", "minidump"]
 categories = ["external-ffi-bindings", "development-tools::debugging"]
-
 exclude = [
-    # Exclude test data for breakpad, as it's unnecessary and can break during
-    # unpacking on windows depending on the how long the user's .cargo path is
-    "sentry-native/external/breakpad/src/processor/testdata/**",
-    "sentry-native/external/breakpad/src/tools/windows/dump_syms/testdata/**",
+  # exclude test data, as it's unnecessary and can break during unpacking on windows depending on how long the user's path is
+  "sentry-native/external/breakpad/src/client/mac/handler/testcases/testdata",
+  "sentry-native/external/breakpad/src/common/testdata",
+  "sentry-native/external/breakpad/src/processor/testdata",
+  "sentry-native/external/breakpad/src/tools/solaris/dump_syms/testdata",
+  "sentry-native/external/breakpad/src/tools/windows/dump_syms/testdata",
+  "sentry-native/external/crashpad/util/net/testdata",
 ]
 
 [build-dependencies]


### PR DESCRIPTION
I came across a path issue when unpacking the crate on Windows due to MAX_PATH, this change removes some test data for breakpad that caused this issue since it could crop up fairly easily depending on how long a user's root .cargo path is. This ended up shaving off almost 3MiB from the crate tarball and around 15MiB from the unpacked source.