### PR TITLE
feat: Update to latest sentry-native 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,15 +37,14 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed thread-safety in almost all functions that could otherwise crash the
+  application or cause undefined behaviour.
 - Improved naming of libraries in the documentation.
 - Exclude some folders from the included Sentry Native SDK that are only
   relevant for testing from the Crates.io package. This not only reduces the
   size of the overall package, but also helps to avoid issues with Windows's
   maximum path length.
 - Improved README.
-- Removed unnecessary thread-safety in almost all functions, this is now handled
-  upstream which also fixed some missing thread-safety that could crash the
-  application or cause undefined behaviour otherwise.
 - Fixed unnecessary include of the WinHttp library when the default transport is
   disabled.
 - Fixed `set_http_proxy` documentation to state that the full scheme is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Added support for changing the backend.
 - Added support for Android.
+- Added support for userdata for `Options::set_logger` through the `Logger`
+  trait.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
   trait.
 - Added `Options::set_auto_session_tracking` and
   `Options::auto_session_tracking`.
+- Added missing documentation for `session_start` and `session_end`.
 
 ### Changed
 
@@ -41,13 +42,16 @@ and this project adheres to
   relevant for testing from the Crates.io package. This not only reduces the
   size of the overall package, but also helps to avoid issues with Windows's
   maximum path length.
+- Improved README.
 - Removed unnecessary thread-safety in almost all functions, this is now handled
   upstream which also fixed some missing thread-safety that could crash the
   application or cause undefined behaviour otherwise.
 - Fixed unnecessary include of the WinHttp library when the default transport is
   disabled.
-- Updated `set_http_proxy` documentation to state that the full scheme is
+- Fixed `set_http_proxy` documentation to state that the full scheme is
   required.
+- Fixed `Transport::send` documentation to state that envelopes have to be sent
+  in order for sessions to work.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 - Added support for Android.
 - Added support for userdata for `Options::set_logger` through the `Logger`
   trait.
+- Added `Options::set_auto_session_tracking` and
+  `Options::auto_session_tracking`.
 
 ### Changed
 
@@ -22,16 +24,10 @@ and this project adheres to
 - Renamed `user_consent_get` to `user_consent`.
 - Renamed feature `default-transport` to `transport-default` and
   `custom-transport` to `transport-custom`.
-- Improved naming of libraries in the documentation.
-- Exclude some folders from the included Sentry Native SDK that are only
-  relevant for testing from the Crates.io package. This not only reduces the
-  size of the overall package, but also helps to avoid issues with Windows's
-  maximum path length.
 - Updated `sentry-native` to 0.4.0.
-- Improved README.
 - Changed the default backend for Linux to Crashpad.
 - Changed the default transport for Android to Curl.
-- Changed `set_transport` `startup` argument to return `Result` and fail
+- Changed `set_transport`'s `startup` argument to return `Result` and fail
   `Options::init` if `Err` is returned.
 
 ### Deprecated
@@ -40,11 +36,18 @@ and this project adheres to
 
 ### Fixed
 
+- Improved naming of libraries in the documentation.
+- Exclude some folders from the included Sentry Native SDK that are only
+  relevant for testing from the Crates.io package. This not only reduces the
+  size of the overall package, but also helps to avoid issues with Windows's
+  maximum path length.
 - Removed unnecessary thread-safety in almost all functions, this is now handled
   upstream which also fixed some missing thread-safety that could crash the
   application or cause undefined behaviour otherwise.
 - Fixed unnecessary include of the WinHttp library when the default transport is
   disabled.
+- Updated `set_http_proxy` documentation to state that the full scheme is
+  required.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - Added support for changing the backend.
+- Added support for Android.
 
 ### Changed
 
@@ -24,6 +25,12 @@ and this project adheres to
   relevant for testing from the Crates.io package. This not only reduces the
   size of the overall package, but also helps to avoid issues with Windows's
   maximum path length.
+- Updated `sentry-native` to 0.4.0.
+- Improved README.
+- Changed the default backend for Linux to Crashpad.
+- Changed the default transport for Android to Curl.
+- Changed `set_transport` `startup` argument to return `Result` and fail
+  `Options::init` if `Err` is returned.
 
 ### Deprecated
 
@@ -31,8 +38,9 @@ and this project adheres to
 
 ### Fixed
 
-- Fixed thread-safety in almost all functions, they could crash the application
-  otherwise or cause undefined behaviour.
+- Removed unnecessary thread-safety in almost all functions, this is now handled
+  upstream which also fixed some missing thread-safety that could crash the
+  application or cause undefined behaviour otherwise.
 - Fixed unnecessary include of the WinHttp library when the default transport is
   disabled.
 
@@ -50,7 +58,7 @@ and this project adheres to
   position if any are found.
 - Improved links to the documentation for the `master` branch.
 - Improved general documentation.
-- Update `vsprintf` to the new official version.
+- Updated `vsprintf` to the new official version.
 - Improved `custom-transport` example.
 
 ### Fixed

--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,7 @@ use std::{
 
 fn main() {
     if let Ok(handler) = env::var("DEP_SENTRY_NATIVE_CRASHPAD_HANDLER") {
+        println!("cargo:rustc-cfg=crashpad");
         println!("cargo:rustc-env=CRASHPAD_HANDLER={}", handler);
 
         let out_dir: PathBuf = env::var_os("OUT_DIR").expect("out dir not set").into();

--- a/examples/custom-transport.rs
+++ b/examples/custom-transport.rs
@@ -50,7 +50,7 @@ struct Transport {
 
 impl Transport {
     /// Create a new [`Transport`].
-    fn new(client: Client, options: &Options) -> Self {
+    fn new(client: Client, options: &Options) -> Result<Self, ()> {
         let (sender, mut receiver) = mpsc::channel::<RawEnvelope>(1024);
         let shutdown = Arc::new((Mutex::new(()), Condvar::new()));
         let transport = Self {
@@ -81,7 +81,7 @@ impl Transport {
             cvar.notify_one();
         });
 
-        transport
+        Ok(transport)
     }
 }
 

--- a/sentry-contrib-native-sys/README.md
+++ b/sentry-contrib-native-sys/README.md
@@ -30,8 +30,8 @@ For more details see
 
 ## Crate features
 
-- **backend-default** - **Enabled by default**, will use Crashpad on MacOS and
-  Windows, Breakpad on Linux and InProc for Android. See `SENTRY_BACKEND` at the
+- **backend-default** - **Enabled by default**, will use Crashpad on Linux,
+  MacOS and Windows and InProc for Android. See `SENTRY_BACKEND` at the
   [Sentry Native SDK](https://github.com/getsentry/sentry-native).
 - **transport-default** - **Enabled by default**, will use WinHttp on Windows
   and Curl everywhere else as the default transport.

--- a/sentry-contrib-native-sys/src/lib.rs
+++ b/sentry-contrib-native-sys/src/lib.rs
@@ -469,6 +469,8 @@ extern "C" {
     pub fn options_get_dist(opts: *const Options) -> *const c_char;
 
     /// Configures the http proxy.
+    ///
+    /// The given proxy has to include the full scheme, eg. `http://some.proxy/`.
     #[link_name = "sentry_options_set_http_proxy"]
     pub fn options_set_http_proxy(opts: *mut Options, proxy: *const c_char);
 

--- a/src/before_send.rs
+++ b/src/before_send.rs
@@ -3,7 +3,7 @@
 use crate::{ffi, Value};
 #[cfg(doc)]
 use crate::{Event, Options};
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
 #[cfg(doc)]
 use std::process::abort;
 use std::{mem::ManuallyDrop, os::raw::c_void, sync::Mutex};
@@ -12,7 +12,7 @@ use std::{mem::ManuallyDrop, os::raw::c_void, sync::Mutex};
 pub type Data = Box<Box<dyn BeforeSend>>;
 
 /// Store [`Options::set_before_send`] data to properly deallocate later.
-pub static BEFORE_SEND: OnceCell<Mutex<Option<Data>>> = OnceCell::new();
+pub static BEFORE_SEND: Lazy<Mutex<Option<Data>>> = Lazy::new(|| Mutex::new(None));
 
 /// Trait to help pass data to [`Options::set_before_send`].
 ///

--- a/src/breadcrumb.rs
+++ b/src/breadcrumb.rs
@@ -2,7 +2,7 @@
 
 #[cfg(doc)]
 use crate::Event;
-use crate::{global_write, Object, RToC, Value};
+use crate::{Object, RToC, Value};
 use std::{
     collections::BTreeMap,
     ffi::CStr,
@@ -99,11 +99,7 @@ impl Breadcrumb {
     /// ```
     pub fn add(self) {
         let breadcrumb = self.into_raw();
-
-        {
-            let _lock = global_write();
-            unsafe { sys::add_breadcrumb(breadcrumb) }
-        }
+        unsafe { sys::add_breadcrumb(breadcrumb) }
     }
 }
 

--- a/src/breadcrumb.rs
+++ b/src/breadcrumb.rs
@@ -2,7 +2,7 @@
 
 #[cfg(doc)]
 use crate::Event;
-use crate::{Object, RToC, Value};
+use crate::{global_lock, Object, RToC, Value};
 use std::{
     collections::BTreeMap,
     ffi::CStr,
@@ -99,7 +99,11 @@ impl Breadcrumb {
     /// ```
     pub fn add(self) {
         let breadcrumb = self.into_raw();
-        unsafe { sys::add_breadcrumb(breadcrumb) }
+
+        {
+            let _lock = global_lock();
+            unsafe { sys::add_breadcrumb(breadcrumb) }
+        }
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 //! Sentry event implementation.
 
-use crate::{CToR, Level, Map, Object, RToC, Value};
+use crate::{global_lock, CToR, Level, Map, Object, RToC, Value};
 use std::{
     cmp::Ordering,
     collections::BTreeMap,
@@ -210,7 +210,11 @@ impl Event {
     #[allow(clippy::must_use_candidate)]
     pub fn capture(self) -> Uuid {
         let event = self.into_raw();
-        Uuid(unsafe { sys::capture_event(event) })
+
+        {
+            let _lock = global_lock();
+            Uuid(unsafe { sys::capture_event(event) })
+        }
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 //! Sentry event implementation.
 
-use crate::{global_write, CToR, Level, Map, Object, RToC, Value};
+use crate::{CToR, Level, Map, Object, RToC, Value};
 use std::{
     cmp::Ordering,
     collections::BTreeMap,
@@ -210,11 +210,7 @@ impl Event {
     #[allow(clippy::must_use_candidate)]
     pub fn capture(self) -> Uuid {
         let event = self.into_raw();
-
-        {
-            let _lock = global_write();
-            Uuid(unsafe { sys::capture_event(event) })
-        }
+        Uuid(unsafe { sys::capture_event(event) })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,18 +588,20 @@ fn fingerprint_invalid() {
     crate::set_fingerprint(fingerprints).unwrap()
 }
 
-/*#[cfg(test)]
+#[cfg(test)]
+#[test]
 #[rusty_fork::test_fork(timeout_ms = 60000)]
 fn threaded_stress() -> anyhow::Result<()> {
     use std::thread;
 
     fn spawns(tests: Vec<fn(i32)>) {
         let mut spawns = Vec::with_capacity(tests.len());
+
         for test in tests {
             let handle = thread::spawn(move || {
                 let mut handles = Vec::with_capacity(100);
 
-                for index in 0..100 {
+                for index in 0..10 {
                     handles.push(thread::spawn(move || test(index)))
                 }
 
@@ -644,7 +646,11 @@ fn threaded_stress() -> anyhow::Result<()> {
         |index| crate::remove_tag(index.to_string()),
         |index| crate::set_extra(index.to_string(), index),
         |index| crate::remove_extra(index.to_string()),
-        |index| crate::set_context(index.to_string(), vec![(index.to_string(), index)]),
+        //|index| crate::set_context(index.to_string(), vec![(index.to_string(), index)]),
+        |index| {
+            let key = std::ffi::CString::new(index.to_string()).unwrap();
+            unsafe { sys::set_context(key.as_ptr(), sys::value_new_int32(index)) }
+        },
         |index| crate::remove_context(index.to_string()),
         |index| crate::set_fingerprint(vec![index.to_string()]).unwrap(),
         |_| crate::remove_fingerprint(),
@@ -669,4 +675,4 @@ fn threaded_stress() -> anyhow::Result<()> {
     test::verify_panics();
 
     Ok(())
-}*/
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,18 +496,35 @@ pub fn set_level(level: Level) {
     unsafe { sys::set_level(level.into_raw()) }
 }
 
-/// Starts a new session.
+/// Starts a new session. By default sessions are started automatically on
+/// [`Options::init`].
 ///
 /// # Examples
-/// TODO
+/// ```
+/// # use sentry_contrib_native::{Options, start_session};
+/// # fn main() -> anyhow::Result<()> {
+/// let mut options = Options::new();
+/// options.set_auto_session_tracking(false);
+/// let _shutdown = options.init()?;
+///
+/// start_session();
+/// # Ok(()) }
+/// ```
 pub fn start_session() {
     unsafe { sys::start_session() }
 }
 
-/// Ends a session.
+/// Prematurely end a session before it is done automatically by [`shutdown`].
 ///
 /// # Examples
-/// TODO
+/// ```
+/// # use sentry_contrib_native::end_session;
+/// // end session prematurely
+/// end_session();
+///
+/// // run some code that isn't part of the session
+/// println!("If this fails, it will not be recorded as part of the session!");
+/// ```
 pub fn end_session() {
     unsafe { sys::end_session() }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -42,7 +42,12 @@ impl Display for Message {
 /// user defined one.
 ///
 /// This function will catch any unwinding panics and [`abort`] if any occured.
-pub extern "C" fn logger(level: i32, message: *const c_char, args: *mut c_void) {
+pub extern "C" fn logger(
+    level: i32,
+    message: *const c_char,
+    args: *mut c_void,
+    _userdata: *mut c_void,
+) {
     let lock = LOGGER.read();
     let logger = lock
         .as_ref()

--- a/src/options.rs
+++ b/src/options.rs
@@ -732,15 +732,14 @@ impl Options {
         *BEFORE_SEND.lock().expect("lock poisoned") = self.before_send.take();
         *LOGGER.lock().expect("lock poisoned") = self.logger.take();
 
-        match unsafe { sys::init(options) } {
-            0 => Ok(Shutdown),
-            _ => {
-                // deallocate unused globals
-                BEFORE_SEND.lock().expect("lock poisoned").take();
-                LOGGER.lock().expect("lock poisoned").take();
+        if unsafe { sys::init(options) } == 0 {
+            Ok(Shutdown)
+        } else {
+            // deallocate unused globals
+            BEFORE_SEND.lock().expect("lock poisoned").take();
+            LOGGER.lock().expect("lock poisoned").take();
 
-                Err(Error::Init)
-            }
+            Err(Error::Init)
         }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -123,6 +123,7 @@ impl Shutdown {
 ///         let dsn = self.dsn.clone();
 ///         let client = self.client.clone();
 ///
+///         // in a correct implementation envelopes have to be send in order for sessions for work
 ///         std::thread::spawn(move || {
 ///             let request = envelope
 ///                 .to_request(dsn)
@@ -146,10 +147,13 @@ impl Shutdown {
 /// # } Ok(()) }
 /// ```
 /// See the
-/// [`transport-custom`](https://github.com/daxpedda/sentry-contrib-native/blob/master/examples/transport-custom.rs)
+/// [`transport-custom`](https://github.com/daxpedda/sentry-contrib-native/blob/master/examples/custom-transport.rs)
 /// example for a more sophisticated implementation.
 pub trait Transport: 'static + Send + Sync {
-    /// Sends the specified Envelope to a Sentry service.
+    /// Sends the specified envelope to a Sentry service.
+    ///
+    /// It is **required** to send envelopes in order for sessions to work
+    /// correctly.
     ///
     /// It is **highly** recommended to not block in this method, but rather
     /// to enqueue the worker to another thread.
@@ -256,7 +260,7 @@ pub extern "C" fn shutdown(timeout: u64, state: *mut c_void) -> c_int {
     }
 }
 
-/// Wrapper for the raw Envelope that we should send to Sentry.
+/// Wrapper for the raw envelope that we should send to Sentry.
 ///
 /// # Examples
 /// ```

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -178,10 +178,14 @@ impl<T: Fn(RawEnvelope) + 'static + Send + Sync> Transport for T {
     }
 }
 
+/// Type used to store the startup function.
+type Startup =
+    Box<dyn (FnOnce(&Options) -> Result<Box<dyn Transport>, ()>) + 'static + Send + Sync>;
+
 /// Internal state of the [`Transport`].
 pub enum State {
     /// [`Transport`] is in the startup phase.
-    Startup(Box<dyn (FnOnce(&Options) -> Result<Box<dyn Transport>, ()>) + 'static + Send + Sync>),
+    Startup(Startup),
     /// [`Transport`] is in the sending phase.
     Send(Box<dyn Transport>),
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,6 +1,6 @@
 //! Sentry user implementation.
 
-use crate::{global_write, Object, Value};
+use crate::{Object, Value};
 use std::{
     collections::BTreeMap,
     ops::{Deref, DerefMut},
@@ -80,11 +80,7 @@ impl User {
     /// ```
     pub fn set(self) {
         let user = self.into_raw();
-
-        {
-            let _lock = global_write();
-            unsafe { sys::set_user(user) };
-        }
+        unsafe { sys::set_user(user) };
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,6 +1,6 @@
 //! Sentry user implementation.
 
-use crate::{Object, Value};
+use crate::{global_lock, Object, Value};
 use std::{
     collections::BTreeMap,
     ops::{Deref, DerefMut},
@@ -80,7 +80,11 @@ impl User {
     /// ```
     pub fn set(self) {
         let user = self.into_raw();
-        unsafe { sys::set_user(user) };
+
+        {
+            let _lock = global_lock();
+            unsafe { sys::set_user(user) };
+        }
     }
 }
 

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -5,15 +5,17 @@
     clippy::pedantic,
     missing_docs
 )]
-#![cfg(any(target_os = "macos", target_os = "windows"))]
+#![cfg(crashpad)]
 
 mod util;
 
 use anyhow::Result;
 use serde_json::Value;
-// use sha1::{Digest, Sha1};
-// use std::fs;
-use std::path::{Path, PathBuf};
+use sha1::{Digest, Sha1};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 fn lib_path() -> PathBuf {
     let mut path = PathBuf::from(env!("OUT_DIR"))
@@ -60,12 +62,12 @@ async fn crash() -> Result<()> {
             assert_eq!("release-pgo", event.dist.unwrap());
             assert_eq!("release-pgo", event.tags.get("dist").unwrap());
 
-            /*let attachment = event.attachments.get(0).unwrap();
+            let attachment = event.attachments.get("attachment.txt").unwrap();
             let content = fs::read_to_string("tests/res/attachment.txt").unwrap();
             let hash = hex::encode(Sha1::digest(content.as_bytes()));
             assert_eq!("attachment.txt", attachment.name);
             assert_eq!(hash, attachment.sha1);
-            assert_eq!(content.len(), attachment.size);*/
+            assert_eq!(content.len(), attachment.size);
         }
 
         // breadcrumb

--- a/tests/crash_failure.rs
+++ b/tests/crash_failure.rs
@@ -5,7 +5,7 @@
     clippy::pedantic,
     missing_docs
 )]
-#![cfg(any(target_os = "macos", target_os = "windows"))]
+#![cfg(crashpad)]
 
 mod util;
 

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -44,7 +44,7 @@ async fn options() -> Result<()> {
                 assert_eq!("release-pgo", event.dist.unwrap());
                 assert_eq!("release-pgo", event.tags.get("dist").unwrap());
 
-                let attachment = event.attachments.get(0).unwrap();
+                let attachment = event.attachments.get("attachment.txt").unwrap();
                 let content = fs::read_to_string("tests/res/attachment.txt").unwrap();
                 let hash = hex::encode(Sha1::digest(content.as_bytes()));
                 assert_eq!("attachment.txt", attachment.name);

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -22,7 +22,7 @@ async fn options() -> Result<()> {
             options.set_environment("production");
             options.set_distribution("release-pgo");
             options.set_ca_certs("tests/res/getsentry.pem");
-            options.add_attachment("test attachment", "tests/res/attachment.txt");
+            options.add_attachment("tests/res/attachment.txt");
         }),
         vec![(
             || Event::new().capture(),

--- a/tests/res/crash.rs
+++ b/tests/res/crash.rs
@@ -48,10 +48,7 @@ async fn main() -> Result<()> {
     options.set_release("1.0");
     options.set_environment("production");
     options.set_distribution("release-pgo");
-    /*options.add_attachment(
-        "test attachment",
-        "C:/rust/sentry-contrib-native/tests/res/attachment.txt",
-    );*/
+    options.add_attachment("tests/res/attachment.txt");
     #[cfg(feature = "transport-custom")]
     options.set_transport(Transport::new);
     let _shutdown = options.init()?;

--- a/tests/util/custom_transport.rs
+++ b/tests/util/custom_transport.rs
@@ -4,7 +4,7 @@ use futures_util::{future::Map, FutureExt};
 use reqwest::Client;
 use sentry::{Dsn, Options, RawEnvelope, Transport as SentryTransport, TransportShutdown};
 use sentry_contrib_native as sentry;
-use std::{convert::TryInto, process, str::FromStr, time::Duration};
+use std::{convert::TryInto, process, time::Duration};
 use tokio::{
     sync::mpsc::{self, Receiver, Sender},
     task::{JoinError, JoinHandle},
@@ -20,17 +20,17 @@ pub struct Transport {
 }
 
 impl Transport {
-    pub fn new(options: &Options) -> Self {
-        let dsn = Dsn::from_str(options.dsn().expect("no DSN found")).expect("invalid DSN");
+    pub fn new(options: &Options) -> Result<Self, ()> {
+        let dsn = options.dsn().and_then(|dsn| Dsn::new(dsn).ok()).ok_or(())?;
         let (sender, receiver) = mpsc::channel(1024);
         let client = Client::new();
 
-        Self {
+        Ok(Self {
             dsn,
             receiver,
             sender,
             client,
-        }
+        })
     }
 }
 

--- a/tests/util/event.rs
+++ b/tests/util/event.rs
@@ -17,7 +17,7 @@ pub struct Event {
     pub release: Option<Release>,
     pub dist: Option<String>,
     #[serde(default)]
-    pub attachments: Vec<Attachment>,
+    pub attachments: HashMap<String, Attachment>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -427,7 +427,7 @@ async fn external_events_internal(
                     .stdout(Stdio::inherit())
                     .stderr(Stdio::inherit())
                     .spawn()
-                    .expect("make sure to build the panic example first!");
+                    .expect("make sure to build the example first!");
                 child.stdin.as_mut().unwrap().write_all(&id).await?;
 
                 assert!(!child.await?.success());


### PR DESCRIPTION
This updates the submodule to https://github.com/getsentry/sentry-native/pull/335, which should land hopefully soon and which will then be released as `0.4.0`.

Just putting this up so we can run this through your excellent testsuite as well ;-) (which I do have some problems getting to work locally however -_-)

Since we have done quite some bulletproofing, it might be worth removing any kind of locking you do around the global options / API. Can you point me in the right direction there maybe?