### PR TITLE
Build fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to
 - Changed the default transport for Android to Curl.
 - Changed `set_transport`'s `startup` argument to return `Result` and fail
   `Options::init` if `Err` is returned.
+- Changed zlib for Crashpad to build from source.
 
 ### Fixed
 
@@ -63,6 +64,7 @@ and this project adheres to
   required.
 - Fixed `Transport::send` documentation to state that envelopes have to be sent
   in order for sessions to work.
+- Fixed cross-compiling for MSVC with `crt-static`.
 
 ## [0.1.0-rc] - 2020-07-06
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ The default backend for Linux is changed from Breakpad to Crashpad.
 
 The default transport for Android is changed from none to Curl.
 
+The default behaviour of including the system shared zlib is disabled and
+instead built from source.
+
 Only the default backend is tested in the CI.
 
 ## Build

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -200,7 +200,10 @@ fn build(
 
     cmake_config.define("SENTRY_BACKEND", backend.as_ref());
 
-    if cfg!(target_feature = "crt-static") {
+    if env::var("CARGO_CFG_TARGET_FEATURE")
+        .unwrap_or_default()
+        .contains("crt-static")
+    {
         cmake_config.define("SENTRY_BUILD_RUNTIMESTATIC", "ON");
     }
 

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -207,8 +207,12 @@ fn build(
     if let Backend::Crashpad = backend {
         cmake_config.define("CRASHPAD_ZLIB_SYSTEM", "OFF");
 
-        if target_os == "macos" {
+        if target_os == "linux" || target_os == "macos" {
             cmake_config.cflag("-mpclmul");
+        }
+
+        if target_os == "linux" {
+            cmake_config.cflag("-msse4.1");
         }
     }
 

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 /// Represents used backend for `sentry-native`.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 enum Backend {
     /// Crashpad backend.
     Crashpad,
@@ -200,12 +200,16 @@ fn build(
 
     cmake_config.define("SENTRY_BACKEND", backend.as_ref());
 
-    // By default, crashpad will attempt to link to the system's shared zlib
+    // By default, Crashpad will attempt to link to the system's shared zlib
     // instead of compiling from source, when targetting non-msvc targets,
     // but this is not a very nice thing to do when the source is already
-    // available
-    if backend == Backend::Crashpad {
+    // available.
+    if let Backend::Crashpad = backend {
         cmake_config.define("CRASHPAD_ZLIB_SYSTEM", "OFF");
+
+        if target_os == "macos" {
+            cmake_config.cflag("-mpclmul");
+        }
     }
 
     if env::var("CARGO_CFG_TARGET_FEATURE")

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 /// Represents used backend for `sentry-native`.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 enum Backend {
     /// Crashpad backend.
     Crashpad,
@@ -199,6 +199,14 @@ fn build(
     }
 
     cmake_config.define("SENTRY_BACKEND", backend.as_ref());
+
+    // By default, crashpad will attempt to link to the system's shared zlib
+    // instead of compiling from source, when targetting non-msvc targets,
+    // but this is not a very nice thing to do when the source is already
+    // available
+    if backend == Backend::Crashpad {
+        cmake_config.define("CRASHPAD_ZLIB_SYSTEM", "OFF");
+    }
 
     if env::var("CARGO_CFG_TARGET_FEATURE")
         .unwrap_or_default()


### PR DESCRIPTION
This turns off the usage of the system zlib when building crashpad, but I could also make it a feature toggle if you want.

Also fixes a bug when cross-compiling for windows, the crt-static feature is only passed when the host is also windows-msvc, which is not the case when cross-compiling.

Resolves: #14