### PR TITLE
Resolve linker errors on Android

### DIFF
--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -164,7 +164,9 @@ fn main() -> Result<()> {
 
             println!("cargo:rustc-link-lib=dylib=stdc++");
         }
-        "android" | "androideabi" => {}
+        "android" | "androideabi" => {
+            println!("cargo:rustc-link-lib=unwindstack");
+        }
         other => unimplemented!("target platform {} not implemented", other),
     }
 

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -166,6 +166,7 @@ fn main() -> Result<()> {
         }
         "android" | "androideabi" => {
             println!("cargo:rustc-link-lib=unwindstack");
+            println!("cargo:rustc-link-lib=c++_static");
         }
         other => unimplemented!("target platform {} not implemented", other),
     }


### PR DESCRIPTION
#### `libunwindstack`

>    The following runtime error is observed:
>    
>        E AndroidRuntime: java.lang.UnsatisfiedLinkError: Unable to load native library "/data/app/rust.android_sentry_test-Yy4WfzwryrPfjq0cWnraYA==/lib/arm64/libandroid_sentry_test.so": dlopen failed: cannot locate symbol "_ZN11unwindstack4MapsD2Ev" referenced by "/data/app/rust.android_sentry_test-Yy4WfzwryrPfjq0cWnraYA==/lib/arm64/libandroid_sentry_test.so"...
>    
>    This occurs because Android includes its own libunwindstack that doesn't
>    match the version provided by Sentry's modified libunwindstack-ndk.

`libunwindstack` is a private, static library dependency of `sentry` yet ends up in the transitive dependency list of `sentry` instead of being linked in by CMake. According to [stackoverflow](https://stackoverflow.com/q/40183810/2844473) that should work just fine but commenting out the export for `libunwindstack`:

https://github.com/getsentry/sentry-native/blob/b908a7a59cc68c49fb98253d8052fe7f57602e9c/CMakeLists.txt#L340-L343

results in a similar CMake error. I've not understood this yet but temporarily linking to the library from `cargo` ensures the right code is available at runtime, resolving the issue.

Let me know if I'm overlooking something obvious here.

The following mail thread over at CMake seems to cover a similar issue but for imported targets: https://cmake.org/pipermail/cmake/2016-August/064054.html, this may or may not be relevant.

#### STL symbols

>    Android [does not provide] a full C++ standard library, this has to be
>    linked in statically or provided with the APK otherwise no STL symbols
>    are available:
>    
>        E AndroidRuntime: java.lang.UnsatisfiedLinkError: Unable to load native library "/data/app/rust.android_sentry_test-BOWYqqIeubPrXvZDTdHfXw==/lib/arm64/libandroid_sentry_test.so": dlopen failed: cannot locate symbol "_ZNSt6__ndk119__shared_weak_countD2Ev" referenced by "/data/app/rust.android_sentry_test-BOWYqqIeubPrXvZDTdHfXw==/lib/arm64/libandroid_sentry_test.so"...
>    
>    I have opted to link against the static library to spare the extra
>    binary that is otherwise bundled with the APK; only few symbols are
>    needed.
>    
>    [does not provide]: https://developer.android.com/ndk/guides/cpp-support

Let me know if the choice to pick static over dynamic is ok here.