### PR TITLE
fix: Handle CARGO_CFG_TARGET_FEATURE with more than just crt-static

### DIFF
--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -198,7 +198,10 @@ fn build(
 
     cmake_config.define("SENTRY_BACKEND", backend.as_ref());
 
-    if let Ok("crt-static") = env::var("CARGO_CFG_TARGET_FEATURE").as_deref() {
+    if env::var("CARGO_CFG_TARGET_FEATURE")
+        .unwrap_or_default()
+        .contains("crt-static")
+    {
         cmake_config.define("SENTRY_BUILD_RUNTIMESTATIC", "ON");
     }
 


### PR DESCRIPTION
https://github.com/daxpedda/sentry-contrib-native/commit/4f249a4ccf1ef1876f7a49bf50c4cf8f603fff01 was only a partial fix.

This -like the original PR- handles cases where `CARGO_CFG_TARGET_FEATURE` has more features; e.g. `"crt-static,fxsr,sse,sse2"`.