### PR TITLE
 Disable usage of system zlib.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 ### Changed
 
 - Changed `zlib` for Crashpad to always build from source.
+- Updated `sentry-native` to `c95dbb0`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 ### Changed
 
+- Changed `zlib` for Crashpad to always build from source.
+
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ The default backend for Linux is changed from Breakpad to Crashpad.
 
 The default transport for Android is changed from none to Curl.
 
+The default behaviour of including the system shared zlib is disabled and
+instead built from source.
+
 Only the default backend is tested in the CI.
 
 ## Build

--- a/sentry-contrib-native-sys/build.rs
+++ b/sentry-contrib-native-sys/build.rs
@@ -198,6 +198,10 @@ fn build(
 
     cmake_config.define("SENTRY_BACKEND", backend.as_ref());
 
+    if let Backend::Crashpad = backend {
+        cmake_config.define("CRASHPAD_ZLIB_SYSTEM", "OFF");
+    }
+
     if let Ok(true) = env::var("CARGO_CFG_TARGET_FEATURE").map(|var| var.contains("crt-static")) {
         cmake_config.define("SENTRY_BUILD_RUNTIMESTATIC", "ON");
     }


### PR DESCRIPTION
Replaces #17.
Fixes #14.

Waiting for [sentry-native](https://github.com/getsentry/sentry-native) to update their crashpad submodule, https://github.com/getsentry/crashpad/pull/22 has already been merged.