### PR TITLE
 Fix cross-compilation from Intel to Apple Silicon MacOS.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,12 @@ jobs:
               test: true,
             }
           - { runner: macos-latest, target: x86_64-apple-darwin, test: true }
-          # - { runner: macos-latest, target: aarch64-apple-darwin, test: false }
+          - {
+              runner: macos-latest,
+              target: aarch64-apple-darwin,
+              test: false,
+              SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk,
+            }
           - {
               runner: windows-latest,
               target: x86_64-pc-windows-msvc,
@@ -106,6 +111,7 @@ jobs:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
       CARGO_BUILD_TARGET: ${{ matrix.os.target }}
+      SDKROOT: ${{ matrix.os.SDKROOT }}
 
     steps:
       - name: Load last run details

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "sentry-contrib-native-sys/sentry-native"]
 	path = sentry-contrib-native-sys/sentry-native
-	url = https://github.com/getsentry/sentry-native.git
+	url = https://github.com/daxpedda/sentry-native.git
+	branch = zlib-apple-silicon

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "sentry-contrib-native-sys/sentry-native"]
 	path = sentry-contrib-native-sys/sentry-native
-	url = https://github.com/daxpedda/sentry-native.git
-	branch = zlib-apple-silicon
+	url = https://github.com/getsentry/sentry-native.git

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Currently the following systems are tested with CI:
 
 - x86_64-unknown-linux-gnu
 - x86_64-apple-darwin
+- aarch64-apple-darwin (building only)
 - x86_64-pc-windows-msvc
 
 See the [CI itself](https://github.com/daxpedda/sentry-contrib-native/actions)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -35,14 +35,10 @@ impl CPath for PathBuf {
         #[cfg(windows)]
         let path = path.encode_wide();
         #[cfg(not(windows))]
-        let path = {
-            let path = path.into_vec().into_iter();
-
-            #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
-            let path = path.map(|ch| unsafe { mem::transmute::<u8, i8>(ch) });
-
-            path
-        };
+        let path = path
+            .into_vec()
+            .into_iter()
+            .map(|ch| unsafe { mem::transmute::<u8, i8>(ch) });
 
         path.take_while(|ch| *ch != 0).chain(Some(0)).collect()
     }


### PR DESCRIPTION
Blocked on https://github.com/getsentry/crashpad/pull/34.
Fixes https://github.com/daxpedda/sentry-contrib-native/issues/20.